### PR TITLE
fix: swap ipc channels on hmr

### DIFF
--- a/src-tauri/src/eventsub/client.rs
+++ b/src-tauri/src/eventsub/client.rs
@@ -388,7 +388,6 @@ impl EventSubClient {
             return Err(Error::Generic(anyhow!("No EventSub connection")));
         };
 
-        #[cfg(debug_assertions)]
         if self
             .subscriptions
             .contains(username, &event.to_string())

--- a/src-tauri/src/eventsub/client.rs
+++ b/src-tauri/src/eventsub/client.rs
@@ -388,6 +388,16 @@ impl EventSubClient {
             return Err(Error::Generic(anyhow!("No EventSub connection")));
         };
 
+        #[cfg(debug_assertions)]
+        if self
+            .subscriptions
+            .contains(username, &event.to_string())
+            .await
+        {
+            tracing::trace!("Already subscribed, skipping");
+            return Ok(());
+        }
+
         let version = if V2_EVENTS.contains(&event) { "2" } else { "1" };
 
         let body = json!({

--- a/src-tauri/src/eventsub/mod.rs
+++ b/src-tauri/src/eventsub/mod.rs
@@ -11,7 +11,7 @@ use tauri::{AppHandle, Manager, State};
 use crate::AppState;
 use crate::api::get_access_token;
 use crate::error::Error;
-use crate::ws::forward_to_channel;
+use crate::ws::{channel_sink, forward_to_channel};
 
 #[tauri::command]
 pub async fn connect_eventsub(
@@ -26,13 +26,20 @@ pub async fn connect_eventsub(
     if let Some(client) = &guard.eventsub
         && client.connected()
     {
+        if let Some(sink) = &guard.eventsub_channel {
+            *sink.lock().await = channel;
+        }
+
         return Ok(());
     }
 
     let (incoming, client) = EventSubClient::new(helix, Arc::new(token));
     let client = Arc::new(client);
 
+    let sink = channel_sink(channel);
     guard.eventsub = Some(Arc::clone(&client));
+    guard.eventsub_channel = Some(Arc::clone(&sink));
+
     drop(guard);
 
     async_runtime::spawn(async move {
@@ -46,7 +53,7 @@ pub async fn connect_eventsub(
         }
     });
 
-    forward_to_channel(incoming, channel, "EventSub");
+    forward_to_channel(incoming, sink, "EventSub");
 
     Ok(())
 }

--- a/src-tauri/src/irc/mod.rs
+++ b/src-tauri/src/irc/mod.rs
@@ -5,6 +5,8 @@ mod error;
 pub mod message;
 pub mod websocket;
 
+use std::sync::Arc;
+
 pub use client::IrcClient;
 use config::ClientConfig;
 use error::Error;
@@ -17,6 +19,7 @@ use crate::AppState;
 use crate::api::get_access_token;
 use crate::error::Error as AppError;
 use crate::irc::message::IrcMessage;
+use crate::ws::channel_sink;
 
 #[tracing::instrument(skip_all)]
 #[tauri::command]
@@ -25,6 +28,15 @@ pub async fn connect_irc(
     channel: Channel<ServerMessage>,
 ) -> Result<(), AppError> {
     let mut guard = state.lock().await;
+
+    if guard.irc.is_some() {
+        if let Some(sink) = &guard.irc_channel {
+            *sink.lock().await = channel;
+        }
+
+        return Ok(());
+    }
+
     let token = get_access_token(&guard)?;
     let login = token.login.to_string();
 
@@ -37,21 +49,24 @@ pub async fn connect_irc(
 
     let (mut incoming, client) = IrcClient::new(config);
 
+    let sink = channel_sink(channel);
+    let forward_sink = Arc::clone(&sink);
+
     async_runtime::spawn(async move {
         while let Some(message) = incoming.recv().await {
             let IrcMessage { tags, command, .. } = message.raw();
 
             tracing::trace!(?tags, "Received {command} message");
 
-            if channel.send(message).is_err() {
-                tracing::warn!("IRC frontend channel closed");
-                break;
+            if forward_sink.lock().await.send(message).is_err() {
+                tracing::warn!("IRC channel send failed");
             }
         }
     });
 
     client.connect().await;
     guard.irc = Some(client);
+    guard.irc_channel = Some(sink);
 
     Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,10 +3,14 @@
 use std::sync::{Arc, LazyLock};
 
 use eventsub::EventSubClient;
+use eventsub::client::NotificationPayload;
 use irc::IrcClient;
+use irc::message::ServerMessage;
 use pubsub::PubSubClient;
+use pubsub::client::PubSubMessage;
 use reqwest::header::HeaderMap;
 use seventv::SeventTvClient;
+use ws::ChannelSink;
 use tauri::Manager;
 use tauri::async_runtime::{self, Mutex};
 use tauri::ipc::Invoke;
@@ -47,6 +51,12 @@ pub struct AppState {
     eventsub: Option<Arc<EventSubClient>>,
     seventv: Option<Arc<SeventTvClient>>,
     pubsub: Option<Arc<PubSubClient>>,
+    // Channel sinks are retained so a hot-reloaded frontend can swap in its new
+    // channel without tearing down the live websocket connection.
+    irc_channel: Option<ChannelSink<ServerMessage>>,
+    eventsub_channel: Option<ChannelSink<NotificationPayload>>,
+    seventv_channel: Option<ChannelSink<serde_json::Value>>,
+    pubsub_channel: Option<ChannelSink<PubSubMessage>>,
 }
 
 impl Default for AppState {
@@ -58,6 +68,10 @@ impl Default for AppState {
             eventsub: None,
             seventv: None,
             pubsub: None,
+            irc_channel: None,
+            eventsub_channel: None,
+            seventv_channel: None,
+            pubsub_channel: None,
         }
     }
 }

--- a/src-tauri/src/pubsub/mod.rs
+++ b/src-tauri/src/pubsub/mod.rs
@@ -11,7 +11,7 @@ use tokio::sync::Mutex;
 use crate::AppState;
 use crate::api::get_access_token;
 use crate::error::Error;
-use crate::ws::forward_to_channel;
+use crate::ws::{channel_sink, forward_to_channel};
 
 #[tauri::command]
 pub async fn connect_pubsub(
@@ -24,6 +24,9 @@ pub async fn connect_pubsub(
     if let Some(client) = &guard.pubsub
         && client.connected()
     {
+        if let Some(sink) = &guard.pubsub_channel {
+            *sink.lock().await = channel;
+        }
         return Ok(());
     }
 
@@ -32,7 +35,10 @@ pub async fn connect_pubsub(
     let (PubSubHandles { events, outgoing }, client) = PubSubClient::new(Arc::new(token));
     let client = Arc::new(client);
 
+    let sink = channel_sink(channel);
     guard.pubsub = Some(Arc::clone(&client));
+    guard.pubsub_channel = Some(Arc::clone(&sink));
+
     drop(guard);
 
     async_runtime::spawn(async move {
@@ -46,7 +52,7 @@ pub async fn connect_pubsub(
         }
     });
 
-    forward_to_channel(events, channel, "PubSub");
+    forward_to_channel(events, sink, "PubSub");
 
     Ok(())
 }

--- a/src-tauri/src/seventv/client.rs
+++ b/src-tauri/src/seventv/client.rs
@@ -124,7 +124,9 @@ impl SeventTvClient {
 
     async fn handle_ws_message(&self, msg: WebSocketMessage) {
         match msg.op {
-            0 => {
+            0 =>
+            {
+                #[allow(clippy::collapsible_match)]
                 if self.sender.send(msg.d).is_err() {
                     tracing::warn!("7TV event receiver dropped");
                 }

--- a/src-tauri/src/seventv/mod.rs
+++ b/src-tauri/src/seventv/mod.rs
@@ -11,7 +11,7 @@ use tokio::sync::Mutex;
 use crate::AppState;
 use crate::error::Error;
 use crate::seventv::client::SeventTvHandles;
-use crate::ws::forward_to_channel;
+use crate::ws::{channel_sink, forward_to_channel};
 
 #[tauri::command]
 pub async fn connect_seventv(
@@ -24,6 +24,9 @@ pub async fn connect_seventv(
     if let Some(client) = &state.seventv
         && client.connected()
     {
+        if let Some(sink) = &state.seventv_channel {
+            *sink.lock().await = channel;
+        }
         return Ok(());
     }
 
@@ -31,7 +34,10 @@ pub async fn connect_seventv(
 
     let client = Arc::new(client);
 
+    let sink = channel_sink(channel);
     state.seventv = Some(Arc::clone(&client));
+    state.seventv_channel = Some(Arc::clone(&sink));
+
     drop(state);
 
     async_runtime::spawn(async move {
@@ -45,7 +51,7 @@ pub async fn connect_seventv(
         }
     });
 
-    forward_to_channel(events, channel, "7TV");
+    forward_to_channel(events, sink, "7TV");
 
     Ok(())
 }

--- a/src-tauri/src/ws.rs
+++ b/src-tauri/src/ws.rs
@@ -1,20 +1,26 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use tauri::async_runtime;
 use tauri::ipc::Channel;
 use tokio::sync::{Mutex, mpsc};
 
+pub type ChannelSink<T> = Arc<Mutex<Channel<T>>>;
+
+pub fn channel_sink<T>(channel: Channel<T>) -> ChannelSink<T> {
+    Arc::new(Mutex::new(channel))
+}
+
 pub fn forward_to_channel<T: serde::Serialize + Send + 'static>(
     mut incoming: mpsc::UnboundedReceiver<T>,
-    channel: Channel<T>,
+    sink: ChannelSink<T>,
     label: &'static str,
 ) {
     async_runtime::spawn(async move {
         while let Some(message) = incoming.recv().await {
-            if channel.send(message).is_err() {
-                tracing::warn!("{label} channel closed");
-                break;
+            if sink.lock().await.send(message).is_err() {
+                tracing::warn!("{label} channel send failed");
             }
         }
     });
@@ -76,6 +82,10 @@ impl<V> SubscriptionStore<V> {
             .lock()
             .await
             .insert(sub_key(channel, event), value);
+    }
+
+    pub async fn contains(&self, channel: &str, event: &str) -> bool {
+        self.inner.lock().await.contains_key(&sub_key(channel, event))
     }
 
     pub async fn remove(&self, channel: &str, event: &str) -> Option<V> {

--- a/src/routes/(main)/+layout.svelte
+++ b/src/routes/(main)/+layout.svelte
@@ -17,6 +17,8 @@
 	const { children } = $props();
 
 	onMount(async () => {
+		await app.connect();
+
 		const update = await check();
 		if (!update) return;
 


### PR DESCRIPTION
Only useful for dev; gets rid of most of the "Couldn't find callback id xxx" warnings when hot-reloading a non .svelte file