### PR TITLE
fix: move twitch related commands from built-in

### DIFF
--- a/src/lib/commands/twitch/block-term.ts
+++ b/src/lib/commands/twitch/block-term.ts
@@ -3,7 +3,7 @@ import { ErrorMessage } from "$lib/errors/messages";
 import { defineCommand } from "../util";
 
 export default defineCommand({
-	provider: "Built-in",
+	provider: "Twitch",
 	name: "block-term",
 	description: "Block a term and prevent it from being used in chat",
 	modOnly: true,

--- a/src/lib/commands/twitch/founders.ts
+++ b/src/lib/commands/twitch/founders.ts
@@ -2,7 +2,7 @@ import { foundersQuery } from "$lib/graphql/twitch";
 import { defineCommand } from "../util";
 
 export default defineCommand({
-	provider: "Built-in",
+	provider: "Twitch",
 	name: "founders",
 	description: "Display a list of founders for this channel",
 	async exec(_, channel) {

--- a/src/lib/commands/twitch/hide-pin.ts
+++ b/src/lib/commands/twitch/hide-pin.ts
@@ -1,7 +1,7 @@
 import { defineCommand } from "../util";
 
 export default defineCommand({
-	provider: "Built-in",
+	provider: "Twitch",
 	name: "hide-pin",
 	description: "Hide the pinned message in chat",
 	async exec(_, channel) {

--- a/src/lib/commands/twitch/show-pin.ts
+++ b/src/lib/commands/twitch/show-pin.ts
@@ -1,7 +1,7 @@
 import { defineCommand } from "../util";
 
 export default defineCommand({
-	provider: "Built-in",
+	provider: "Twitch",
 	name: "show-pin",
 	description: "Show the pinned message in chat",
 	async exec(_, channel) {

--- a/src/lib/commands/twitch/unpin.ts
+++ b/src/lib/commands/twitch/unpin.ts
@@ -1,7 +1,7 @@
 import { defineCommand } from "../util";
 
 export default defineCommand({
-	provider: "Built-in",
+	provider: "Twitch",
 	name: "unpin",
 	description: "Unpin the currently pinned message in the channel",
 	modOnly: true,


### PR DESCRIPTION
Originally, I had Twitch commands that were only on the site as Twitch-provided, but I realize this doesn't make much sense