### PR TITLE
refactor(ws): model connection state as a single enum

### DIFF
--- a/src-tauri/src/eventsub/client.rs
+++ b/src-tauri/src/eventsub/client.rs
@@ -132,7 +132,7 @@ impl<'de> Deserialize<'de> for WebSocketMessage {
 pub struct EventSubClient {
     helix: Arc<HelixClient<'static, reqwest::Client>>,
     pub token: Arc<UserToken>,
-    state: ConnectionState,
+    state: ConnectionState<String>,
     pub subscriptions: SubscriptionStore<Subscription>,
     sender: mpsc::UnboundedSender<NotificationPayload>,
     reconnecting: AtomicBool,
@@ -150,7 +150,7 @@ impl EventSubClient {
         let client = Self {
             helix,
             token,
-            state: ConnectionState::new(),
+            state: ConnectionState::connecting(),
             subscriptions: SubscriptionStore::new(),
             sender,
             reconnecting: AtomicBool::default(),
@@ -163,18 +163,22 @@ impl EventSubClient {
     pub async fn connect(&self) -> Result<(), Error> {
         tracing::info!("Connecting to EventSub");
 
-        let (stream, _) = connect_async(TWITCH_EVENTSUB_WS_URI).await.map_err(|err| {
-            tracing::error!(%err, "Failed to connect to EventSub");
-            Error::WebSocket(err)
-        })?;
+        let (stream, _) = match connect_async(TWITCH_EVENTSUB_WS_URI).await {
+            Ok(connected) => connected,
+            Err(err) => {
+                tracing::error!(%err, "Failed to connect to EventSub");
+                self.state.disconnect();
 
+                return Err(Error::WebSocket(err));
+            }
+        };
+
+        // Stays `Connecting` until the welcome message hands us a session id
         tracing::info!("Connected to EventSub");
-        self.state.set_connected(true);
 
         let result = self.process_stream(stream).await;
 
-        self.state.set_connected(false);
-        self.state.set_session_id(None).await;
+        self.state.disconnect();
 
         result
     }
@@ -260,7 +264,7 @@ impl EventSubClient {
         match msg {
             Ws::Welcome(payload) => {
                 tracing::debug!("Set EventSub session id to {}", payload.session.id);
-                self.state.set_session_id(Some(payload.session.id)).await;
+                self.state.set_ready(payload.session.id);
 
                 let was_reconnecting = self.reconnecting.swap(false, Ordering::Relaxed);
 
@@ -373,8 +377,9 @@ impl EventSubClient {
         }
     }
 
-    pub fn connected(&self) -> bool {
-        self.state.connected()
+    /// Whether the client is connected or still establishing its connection.
+    pub fn active(&self) -> bool {
+        self.state.active()
     }
 
     #[tracing::instrument(name = "eventsub_subscribe", skip(self, condition), fields(%condition))]
@@ -384,8 +389,8 @@ impl EventSubClient {
         event: EventType,
         condition: serde_json::Value,
     ) -> Result<(), Error> {
-        let Some(session_id) = self.state.session_id().await else {
-            return Err(Error::Generic(anyhow!("No EventSub connection")));
+        let Some(session_id) = self.state.session() else {
+            return Err(Error::Generic(anyhow!("No EventSub session")));
         };
 
         if self

--- a/src-tauri/src/eventsub/mod.rs
+++ b/src-tauri/src/eventsub/mod.rs
@@ -24,7 +24,7 @@ pub async fn connect_eventsub(
     let helix = Arc::new(guard.helix.clone());
 
     if let Some(client) = &guard.eventsub
-        && client.connected()
+        && client.active()
     {
         if let Some(sink) = &guard.eventsub_channel {
             *sink.lock().await = channel;

--- a/src-tauri/src/pubsub/client.rs
+++ b/src-tauri/src/pubsub/client.rs
@@ -89,7 +89,7 @@ impl PubSubClient {
 
         let client = Self {
             token,
-            state: ConnectionState::new(),
+            state: ConnectionState::connecting(),
             subscriptions: SubscriptionStore::new(),
             sender,
             message_tx,
@@ -108,6 +108,7 @@ impl PubSubClient {
 
         loop {
             tracing::info!("Connecting to Twitch PubSub");
+            self.state.set_connecting();
 
             let mut stream = match connect_async(TWITCH_PUBSUB_WS_URI).await {
                 Ok((stream, _)) => stream,
@@ -122,7 +123,7 @@ impl PubSubClient {
             tracing::info!("Connected to Twitch PubSub");
             backoff = INITIAL_BACKOFF;
 
-            self.state.set_connected(true);
+            self.state.set_ready(());
             self.restore().await;
             self.listen_user_topics();
 
@@ -194,7 +195,9 @@ impl PubSubClient {
                 }
             }
 
-            self.state.set_connected(false);
+            // Stays active across the backoff, since this loop owns the retry
+            self.state.set_connecting();
+
             tracing::info!(?backoff, "Reconnecting to PubSub");
             tokio::time::sleep(backoff).await;
             backoff = (backoff * 2).min(MAX_BACKOFF);
@@ -318,8 +321,9 @@ impl PubSubClient {
         }
     }
 
-    pub fn connected(&self) -> bool {
-        self.state.connected()
+    /// Whether the client is connected or still establishing its connection.
+    pub fn active(&self) -> bool {
+        self.state.active()
     }
 
     #[tracing::instrument(name = "pubsub_listen", skip(self, topics))]

--- a/src-tauri/src/pubsub/mod.rs
+++ b/src-tauri/src/pubsub/mod.rs
@@ -22,7 +22,7 @@ pub async fn connect_pubsub(
     let mut guard = state.lock().await;
 
     if let Some(client) = &guard.pubsub
-        && client.connected()
+        && client.active()
     {
         if let Some(sink) = &guard.pubsub_channel {
             *sink.lock().await = channel;

--- a/src-tauri/src/seventv/client.rs
+++ b/src-tauri/src/seventv/client.rs
@@ -18,7 +18,7 @@ struct WebSocketMessage {
 }
 
 pub struct SeventTvClient {
-    state: ConnectionState,
+    state: ConnectionState<String>,
     subscriptions: SubscriptionStore<serde_json::Value>,
     sender: mpsc::UnboundedSender<serde_json::Value>,
     message_tx: mpsc::UnboundedSender<Message>,
@@ -36,7 +36,7 @@ impl SeventTvClient {
 
         let client = Self {
             subscriptions: SubscriptionStore::new(),
-            state: ConnectionState::new(),
+            state: ConnectionState::connecting(),
             sender,
             message_tx,
         };
@@ -49,20 +49,26 @@ impl SeventTvClient {
         &self,
         mut message_rx: mpsc::UnboundedReceiver<Message>,
     ) -> Result<(), Error> {
+        // Held across reconnects so a session can still be resumed after a drop
+        let mut resume: Option<String> = None;
+
         loop {
             tracing::info!("Connecting to 7TV Event API");
+            self.state.set_connecting();
 
             let mut stream = match connect_async(SEVENTV_WS_URI).await {
                 Ok((stream, _)) => stream,
                 Err(err) => {
                     tracing::error!(%err, "Failed to connect to 7TV Event API");
+                    self.state.disconnect();
+
                     return Err(Error::WebSocket(err));
                 }
             };
 
             tracing::info!("Connected to 7TV Event API");
 
-            if let Some(id) = self.state.session_id().await {
+            if let Some(id) = &resume {
                 tracing::info!(%id, "Resuming 7TV session");
 
                 let payload = json!({
@@ -76,8 +82,6 @@ impl SeventTvClient {
                     tracing::error!(%err, "Error sending resume message");
                 }
             }
-
-            self.state.set_connected(true);
 
             loop {
                 tokio::select! {
@@ -118,7 +122,9 @@ impl SeventTvClient {
                 }
             }
 
-            self.state.set_connected(false);
+            // Keep the previous id when the drop happened before the session
+            // was re-established, so the resume attempt isn't lost
+            resume = self.state.disconnect().or(resume);
         }
     }
 
@@ -133,7 +139,7 @@ impl SeventTvClient {
             }
             1 => {
                 if let Some(id) = msg.d["session_id"].as_str() {
-                    self.state.set_session_id(Some(id.to_string())).await;
+                    self.state.set_ready(id.to_string());
                     tracing::info!(%id, "Hello received, session established");
                 }
             }
@@ -162,8 +168,9 @@ impl SeventTvClient {
         }
     }
 
-    pub fn connected(&self) -> bool {
-        self.state.connected()
+    /// Whether the client is connected or still establishing its connection.
+    pub fn active(&self) -> bool {
+        self.state.active()
     }
 
     #[tracing::instrument(name = "7tv_subscribe", skip(self, condition), fields(%condition))]

--- a/src-tauri/src/seventv/mod.rs
+++ b/src-tauri/src/seventv/mod.rs
@@ -22,7 +22,7 @@ pub async fn connect_seventv(
     let mut state = state.lock().await;
 
     if let Some(client) = &state.seventv
-        && client.connected()
+        && client.active()
     {
         if let Some(sink) = &state.seventv_channel {
             *sink.lock().await = channel;

--- a/src-tauri/src/ws.rs
+++ b/src-tauri/src/ws.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex as SyncMutex, MutexGuard, PoisonError};
 
 use tauri::async_runtime;
 use tauri::ipc::Channel;
@@ -30,32 +29,84 @@ pub fn sub_key(channel: &str, event: &str) -> String {
     format!("{channel}:{event}")
 }
 
-/// Connection-level state shared by every websocket subscription client.
-#[derive(Debug, Default)]
-pub struct ConnectionState {
-    pub session_id: Mutex<Option<String>>,
-    pub connected: AtomicBool,
+/// The lifecycle of a websocket connection.
+///
+/// Kept as a single value so that "is connected" and "has a session" cannot
+/// disagree: a session only exists in [`Connection::Ready`], and the gap
+/// between opening the socket and negotiating the session is its own state
+/// rather than an unrepresentable combination of the two.
+#[derive(Debug)]
+pub enum Connection<S> {
+    Disconnected,
+    /// The socket is being established, or is open but the server has not
+    /// handed out a session yet.
+    Connecting,
+    Ready(S),
 }
 
-impl ConnectionState {
-    pub fn new() -> Self {
-        Self::default()
+/// Connection-level state shared by every websocket subscription client.
+///
+/// `S` is whatever the server hands back to identify the session; clients that
+/// have no such concept use the default of `()`.
+#[derive(Debug)]
+pub struct ConnectionState<S = ()> {
+    inner: SyncMutex<Connection<S>>,
+}
+
+impl<S> Default for ConnectionState<S> {
+    fn default() -> Self {
+        Self {
+            inner: SyncMutex::new(Connection::Disconnected),
+        }
+    }
+}
+
+impl<S> ConnectionState<S> {
+    /// Starts out [`Connection::Connecting`], so a client counts as active from
+    /// the moment it is constructed rather than once its connect task happens
+    /// to be scheduled.
+    pub fn connecting() -> Self {
+        Self {
+            inner: SyncMutex::new(Connection::Connecting),
+        }
     }
 
-    pub fn connected(&self) -> bool {
-        self.connected.load(Ordering::Relaxed)
+    fn lock(&self) -> MutexGuard<'_, Connection<S>> {
+        self.inner.lock().unwrap_or_else(PoisonError::into_inner)
     }
 
-    pub fn set_connected(&self, value: bool) {
-        self.connected.store(value, Ordering::Relaxed);
+    pub fn set_connecting(&self) {
+        *self.lock() = Connection::Connecting;
     }
 
-    pub async fn set_session_id(&self, id: Option<String>) {
-        *self.session_id.lock().await = id;
+    pub fn set_ready(&self, session: S) {
+        *self.lock() = Connection::Ready(session);
     }
 
-    pub async fn session_id(&self) -> Option<String> {
-        self.session_id.lock().await.clone()
+    /// Drops back to [`Connection::Disconnected`], handing back the session
+    /// that was in use, if there was one.
+    pub fn disconnect(&self) -> Option<S> {
+        match std::mem::replace(&mut *self.lock(), Connection::Disconnected) {
+            Connection::Ready(session) => Some(session),
+            _ => None,
+        }
+    }
+
+    /// Whether a connection is live *or* being established. Callers deciding
+    /// whether to spawn a client want this, not [`Self::session`], so that two
+    /// racing connect attempts can't both start one.
+    pub fn active(&self) -> bool {
+        !matches!(*self.lock(), Connection::Disconnected)
+    }
+}
+
+impl<S: Clone> ConnectionState<S> {
+    /// The negotiated session, available only once the connection is ready.
+    pub fn session(&self) -> Option<S> {
+        match &*self.lock() {
+            Connection::Ready(session) => Some(session.clone()),
+            _ => None,
+        }
     }
 }
 


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>