### PR TITLE
refactor(ws): hand out a consuming connector instead of a loose receiver

### DIFF
--- a/src-tauri/src/pubsub/client.rs
+++ b/src-tauri/src/pubsub/client.rs
@@ -79,31 +79,46 @@ pub struct PubSubClient {
 
 pub struct PubSubHandles {
     pub events: mpsc::UnboundedReceiver<PubSubMessage>,
-    pub outgoing: mpsc::UnboundedReceiver<Message>,
+    pub connector: PubSubConnector,
+}
+
+/// Owns the client's outgoing queue and is consumed by connecting, so a client
+/// can only be connected once, and only ever to its own queue.
+pub struct PubSubConnector {
+    client: Arc<PubSubClient>,
+    outgoing: mpsc::UnboundedReceiver<Message>,
+}
+
+impl PubSubConnector {
+    pub async fn connect(self) -> Result<(), Error> {
+        self.client.run(self.outgoing).await
+    }
 }
 
 impl PubSubClient {
-    pub fn new(token: Arc<UserToken>) -> (PubSubHandles, Self) {
+    pub fn new(token: Arc<UserToken>) -> (PubSubHandles, Arc<Self>) {
         let (sender, events) = mpsc::unbounded_channel::<PubSubMessage>();
         let (message_tx, outgoing) = mpsc::unbounded_channel();
 
-        let client = Self {
+        let client = Arc::new(Self {
             token,
             state: ConnectionState::connecting(),
             subscriptions: SubscriptionStore::new(),
             sender,
             message_tx,
             nonce: AtomicU64::new(0),
+        });
+
+        let connector = PubSubConnector {
+            client: Arc::clone(&client),
+            outgoing,
         };
 
-        (PubSubHandles { events, outgoing }, client)
+        (PubSubHandles { events, connector }, client)
     }
 
     #[tracing::instrument(name = "pubsub_connect", skip_all)]
-    pub async fn connect(
-        &self,
-        mut message_rx: mpsc::UnboundedReceiver<Message>,
-    ) -> Result<(), Error> {
+    async fn run(&self, mut message_rx: mpsc::UnboundedReceiver<Message>) -> Result<(), Error> {
         let mut backoff = INITIAL_BACKOFF;
 
         loop {

--- a/src-tauri/src/pubsub/mod.rs
+++ b/src-tauri/src/pubsub/mod.rs
@@ -32,8 +32,7 @@ pub async fn connect_pubsub(
 
     let token = get_access_token(&guard)?.clone();
 
-    let (PubSubHandles { events, outgoing }, client) = PubSubClient::new(Arc::new(token));
-    let client = Arc::new(client);
+    let (PubSubHandles { events, connector }, client) = PubSubClient::new(Arc::new(token));
 
     let sink = channel_sink(channel);
     guard.pubsub = Some(Arc::clone(&client));
@@ -42,7 +41,7 @@ pub async fn connect_pubsub(
     drop(guard);
 
     async_runtime::spawn(async move {
-        if let Err(err) = client.connect(outgoing).await {
+        if let Err(err) = connector.connect().await {
             tracing::error!(%err, "PubSub connection failed");
 
             let state = app_handle.state::<Mutex<AppState>>();

--- a/src-tauri/src/seventv/client.rs
+++ b/src-tauri/src/seventv/client.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use futures::future::join_all;
 use futures::{SinkExt, StreamExt};
 use serde::Deserialize;
@@ -26,29 +28,44 @@ pub struct SeventTvClient {
 
 pub struct SeventTvHandles {
     pub events: mpsc::UnboundedReceiver<serde_json::Value>,
-    pub outgoing: mpsc::UnboundedReceiver<Message>,
+    pub connector: SeventTvConnector,
+}
+
+/// Owns the client's outgoing queue and is consumed by connecting, so a client
+/// can only be connected once, and only ever to its own queue.
+pub struct SeventTvConnector {
+    client: Arc<SeventTvClient>,
+    outgoing: mpsc::UnboundedReceiver<Message>,
+}
+
+impl SeventTvConnector {
+    pub async fn connect(self) -> Result<(), Error> {
+        self.client.run(self.outgoing).await
+    }
 }
 
 impl SeventTvClient {
-    pub fn new() -> (SeventTvHandles, Self) {
+    pub fn new() -> (SeventTvHandles, Arc<Self>) {
         let (sender, events) = mpsc::unbounded_channel::<serde_json::Value>();
         let (message_tx, outgoing) = mpsc::unbounded_channel();
 
-        let client = Self {
+        let client = Arc::new(Self {
             subscriptions: SubscriptionStore::new(),
             state: ConnectionState::connecting(),
             sender,
             message_tx,
+        });
+
+        let connector = SeventTvConnector {
+            client: Arc::clone(&client),
+            outgoing,
         };
 
-        (SeventTvHandles { events, outgoing }, client)
+        (SeventTvHandles { events, connector }, client)
     }
 
     #[tracing::instrument(name = "7tv_connect", skip_all)]
-    pub async fn connect(
-        &self,
-        mut message_rx: mpsc::UnboundedReceiver<Message>,
-    ) -> Result<(), Error> {
+    async fn run(&self, mut message_rx: mpsc::UnboundedReceiver<Message>) -> Result<(), Error> {
         // Held across reconnects so a session can still be resumed after a drop
         let mut resume: Option<String> = None;
 

--- a/src-tauri/src/seventv/mod.rs
+++ b/src-tauri/src/seventv/mod.rs
@@ -30,9 +30,7 @@ pub async fn connect_seventv(
         return Ok(());
     }
 
-    let (SeventTvHandles { events, outgoing }, client) = SeventTvClient::new();
-
-    let client = Arc::new(client);
+    let (SeventTvHandles { events, connector }, client) = SeventTvClient::new();
 
     let sink = channel_sink(channel);
     state.seventv = Some(Arc::clone(&client));
@@ -41,7 +39,7 @@ pub async fn connect_seventv(
     drop(state);
 
     async_runtime::spawn(async move {
-        if let Err(err) = client.connect(outgoing).await {
+        if let Err(err) = connector.connect().await {
             tracing::error!(%err, "7TV connection failed");
 
             let state = app_handle.state::<Mutex<AppState>>();


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>