### PR TITLE
feat(ui): replace Dialog, Popover and Tooltip wrappers

### DIFF
--- a/src/lib/components/ui/Dialog.svelte
+++ b/src/lib/components/ui/Dialog.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+	import type { WithElementRef } from "bits-ui";
+	import type { Snippet } from "svelte";
+	import type { HTMLDialogAttributes } from "svelte/elements";
+	import { cn } from "tailwind-variants";
+
+	interface Props extends WithElementRef<HTMLDialogAttributes> {
+		id: string;
+		alert?: boolean;
+		header?: Snippet;
+		footer?: Snippet;
+	}
+
+	let {
+		id,
+		class: className,
+		alert,
+		ref = $bindable(null),
+		header,
+		children,
+		footer,
+		...rest
+	}: Props = $props();
+</script>
+
+<dialog
+	{id}
+	class={cn(
+		"fixed inset-0 m-auto w-full max-w-[calc(100%-2rem)] space-y-4 rounded-3xl bg-popover p-6 text-popover-foreground smooth-shadow-ring-lg sm:max-w-lg",
+		"scale-95 opacity-0 transition-[opacity,scale,overlay,display] transition-discrete ease-out",
+		className,
+	)}
+	role={alert ? "alertdialog" : null}
+	data-component="dialog"
+	bind:this={ref}
+	{...rest}
+>
+	{#if header}
+		<header
+			class="flex flex-col gap-2 heading:text-lg/1 heading:font-semibold [p]:text-sm [p]:text-muted-foreground"
+			data-slot="dialog-header"
+		>
+			{@render header()}
+		</header>
+	{/if}
+
+	<div class="space-y-4" data-slot="dialog-content">
+		{@render children?.()}
+	</div>
+
+	{#if footer}
+		<footer
+			class="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end"
+			data-slot="dialog-footer"
+		>
+			{@render footer()}
+		</footer>
+	{/if}
+</dialog>
+
+<style>
+	dialog {
+		&::backdrop {
+			background-color: oklch(0% 0 0deg / 50%);
+			opacity: 0;
+			transition:
+				opacity 200ms ease-out,
+				display 200ms ease-out allow-discrete;
+		}
+
+		&:is(:open, [open]) {
+			opacity: 1;
+			scale: 1;
+
+			&::backdrop {
+				opacity: 1;
+				backdrop-filter: blur(6px);
+
+				@starting-style {
+					opacity: 0;
+					backdrop-filter: blur(0);
+				}
+			}
+
+			@starting-style {
+				opacity: 0;
+				scale: 0.95;
+			}
+		}
+	}
+</style>

--- a/src/lib/components/ui/Popover.svelte
+++ b/src/lib/components/ui/Popover.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+	import type { WithElementRef } from "bits-ui";
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn } from "tailwind-variants";
+
+	interface Props extends WithElementRef<HTMLAttributes<HTMLDivElement>> {
+		id: string;
+		side?: "top" | "right" | "bottom" | "left";
+	}
+
+	let {
+		id,
+		class: className,
+		side = "top",
+		ref = $bindable(null),
+		children,
+		...rest
+	}: Props = $props();
+
+	const anchorName = $derived(`--popover-${id}`);
+
+	$effect(() => {
+		const trigger =
+			ref?.previousElementSibling || document.querySelector(`[popovertarget="${id}"]`);
+		if (!(trigger instanceof HTMLElement)) return;
+
+		trigger.style.setProperty("anchor-name", anchorName);
+
+		return () => trigger.style.removeProperty("anchor-name");
+	});
+</script>
+
+<div
+	{id}
+	class={cn(
+		"fixed inset-auto m-0 w-max rounded-xl bg-popover p-4 text-popover-foreground smooth-shadow-ring-md",
+		"scale-95 opacity-0 transition-[opacity,scale,overlay,display] transition-discrete",
+		className,
+	)}
+	popover="auto"
+	data-component="popover"
+	data-side={side}
+	style:position-anchor={anchorName}
+	{...rest}
+	bind:this={ref}
+>
+	{@render children?.()}
+</div>
+
+<style>
+	[data-component="popover"] {
+		&[data-side="top"] {
+			bottom: anchor(top);
+			justify-self: anchor-center;
+			margin-bottom: 0.5rem;
+		}
+
+		&[data-side="bottom"] {
+			top: anchor(bottom);
+			justify-self: anchor-center;
+			margin-top: 0.5rem;
+		}
+
+		&[data-side="left"] {
+			right: anchor(left);
+			align-self: anchor-center;
+			margin-right: 0.5rem;
+		}
+
+		&[data-side="right"] {
+			left: anchor(right);
+			align-self: anchor-center;
+			margin-left: 0.5rem;
+		}
+
+		&:popover-open {
+			opacity: 1;
+			scale: 1;
+
+			@starting-style {
+				opacity: 0;
+				scale: 0.95;
+			}
+		}
+	}
+</style>

--- a/src/lib/components/ui/Tooltip.svelte
+++ b/src/lib/components/ui/Tooltip.svelte
@@ -1,0 +1,117 @@
+<script lang="ts">
+	import type { WithElementRef } from "bits-ui";
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn } from "tailwind-variants";
+
+	interface Props extends WithElementRef<HTMLAttributes<HTMLDivElement>> {
+		side?: "top" | "right" | "bottom" | "left";
+		delay?: number;
+	}
+
+	let {
+		class: className,
+		side = "top",
+		delay = 300,
+		ref = $bindable(null),
+		children,
+		...rest
+	}: Props = $props();
+
+	const id = $props.id();
+
+	const anchorName = `--tooltip-${id}`;
+
+	$effect(() => {
+		const trigger = ref?.previousElementSibling;
+		if (!(trigger instanceof HTMLElement)) return;
+
+		trigger.style.setProperty("anchor-name", anchorName);
+
+		return () => trigger.style.removeProperty("anchor-name");
+	});
+</script>
+
+<div
+	class={cn(
+		"pointer-events-none fixed z-50 rounded-lg bg-neutral-800 px-3 py-1.5 text-xs text-primary opacity-0 smooth-shadow-ring-md transition-[opacity,scale] delay-0",
+		className,
+	)}
+	role="tooltip"
+	data-component="tooltip"
+	data-side={side}
+	style:--tooltip-delay="{delay}ms"
+	style:position-anchor={anchorName}
+	{...rest}
+	bind:this={ref}
+>
+	{@render children?.()}
+</div>
+
+<style>
+	:global([data-slot="tooltip-trigger"]:hover) + [data-component="tooltip"] {
+		opacity: 1;
+		pointer-events: auto;
+		transition-delay: var(--tooltip-delay);
+	}
+
+	[data-component="tooltip"] {
+		--tooltip-arrow-offset: -0.25rem;
+
+		&::after {
+			content: "";
+			position: absolute;
+			width: 0.5rem;
+			height: 0.5rem;
+			background-color: inherit;
+			rotate: 45deg;
+		}
+
+		&[data-side="top"] {
+			bottom: anchor(top);
+			justify-self: anchor-center;
+			margin-bottom: 0.5rem;
+
+			&::after {
+				bottom: var(--tooltip-arrow-offset);
+				left: 50%;
+				translate: -50% 0;
+			}
+		}
+
+		&[data-side="bottom"] {
+			top: anchor(bottom);
+			justify-self: anchor-center;
+			margin-top: 0.5rem;
+
+			&::after {
+				top: var(--tooltip-arrow-offset);
+				left: 50%;
+				translate: -50% 0;
+			}
+		}
+
+		&[data-side="left"] {
+			right: anchor(left);
+			align-self: anchor-center;
+			margin-right: 0.5rem;
+
+			&::after {
+				right: var(--tooltip-arrow-offset);
+				top: 50%;
+				translate: 0 -50%;
+			}
+		}
+
+		&[data-side="right"] {
+			left: anchor(right);
+			align-self: anchor-center;
+			margin-left: 0.5rem;
+
+			&::after {
+				left: var(--tooltip-arrow-offset);
+				top: 50%;
+				translate: 0 -50%;
+			}
+		}
+	}
+</style>


### PR DESCRIPTION
Swaps the multi-file shadcn/bits-ui compound components for three
single-file primitives with a flat API, built on native <dialog> and
explicit popover relationships instead of portalled overlays.

Additive: the old `ui/dialog/`, `ui/popover/` and `ui/tooltip/` barrels
stay in place until the cleanup PR, so nothing is migrated yet.



---

### The stack

Merge bottom-up. Each PR is based on the one above it, and each one
type-checks on its own (`vp run check`, 0 errors).

| # | PR | What |
|---|----|------|
| 1 | #240 | `cn` from tailwind-variants, shadow-plugin, css tokens |
| 2 | #241 | Button restyle + Link |
| 3 | #242 | Slider rebuild |
| 4 | #243 | Dialog / Popover / Tooltip |
| 5 | #244 | Input, Textarea, Checkbox, Switch, Progress, Separator, Label, ColorPicker |
| 6 | #245 | Message components |
| 7 | #246 | `components/stream/` + number-flow |
| 8 | #247 | Kept shadcn wrappers polish |
| 9 | #248 | Settings as a dialog |
| 10 | #249 | Chat, channel views, app shell, data layer |
| 11 | #250 | Drop the orphaned shadcn barrels |

Replaces #207, which was 179 files in one review.

The stack tip is byte-identical to `feat/ui-overhaul-v2` — verified with
`git diff ui/11-cleanup feat/ui-overhaul-v2` (empty).

PRs 2–9 are deliberately **additive**: they add the new component next to
the old one without migrating call sites, so each can be read on its own.
The migrations happen in #249, and #250 deletes what is then unreferenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
