### PR TITLE
feat(ui): flatten and restyle the form controls

### DIFF
--- a/src/lib/components/ui/Checkbox.svelte
+++ b/src/lib/components/ui/Checkbox.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+	import { Checkbox } from "bits-ui";
+	import type { WithoutChildrenOrChild } from "bits-ui";
+	import { cn } from "tailwind-variants";
+	import CheckIcon from "~icons/ph/check";
+	import MinusIcon from "~icons/ph/minus";
+
+	let {
+		class: className,
+		checked = $bindable(false),
+		indeterminate = $bindable(false),
+		ref = $bindable(null),
+		...rest
+	}: WithoutChildrenOrChild<Checkbox.RootProps> = $props();
+</script>
+
+<Checkbox.Root
+	class={cn(
+		"peer flex size-4 shrink-0 items-center justify-center rounded-sm border border-input shadow-xs transition-shadow outline-none",
+		"focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50",
+		"aria-invalid:border-destructive aria-invalid:ring-destructive/20",
+		"data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+		"dark:bg-input/30 dark:aria-invalid:ring-destructive/40 dark:data-[state=checked]:bg-primary",
+		className,
+	)}
+	data-component="checkbox"
+	{...rest}
+	bind:checked
+	bind:indeterminate
+	bind:ref
+>
+	{#snippet children({ checked, indeterminate })}
+		<div class="text-current transition-none" data-slot="checkbox-indicator">
+			{#if checked}
+				<CheckIcon class="size-3.5" />
+			{:else if indeterminate}
+				<MinusIcon class="size-3.5" />
+			{/if}
+		</div>
+	{/snippet}
+</Checkbox.Root>

--- a/src/lib/components/ui/ColorPicker.svelte
+++ b/src/lib/components/ui/ColorPicker.svelte
@@ -4,7 +4,7 @@
 	import type { HTMLAttributes } from "svelte/elements";
 	import { cn } from "tailwind-variants";
 	import { clamp } from "$lib/util";
-	import { Input } from "./input";
+	import Input from "./Input.svelte";
 
 	interface Props extends HTMLAttributes<HTMLDivElement> {
 		value?: chroma.ChromaInput;
@@ -12,12 +12,11 @@
 
 	let { class: className, value = $bindable(), ...rest }: Props = $props();
 
-	const color = $state(chroma(value ?? "#FFFFFF"));
-	const hsv = color.hsv();
+	const hsv = $derived(chroma(value ?? "#FFFFFF").hsv());
 
-	let h = $state(hsv[0] || 0);
-	let s = $state(hsv[1] * 100 || 100);
-	let v = $state(hsv[2] * 100 || 50);
+	let h = $derived(Number.isNaN(hsv[0]) ? 0 : hsv[0]);
+	let s = $derived(hsv[1] * 100);
+	let v = $derived(hsv[2] * 100);
 
 	let well = $state<HTMLElement>();
 	let isDragging = $state(false);
@@ -58,26 +57,28 @@
 	}
 
 	function handleChange(event: Event & { currentTarget: HTMLInputElement }) {
+		if (!chroma.valid(event.currentTarget.value)) return;
+
 		const hsv = chroma(event.currentTarget.value).hsv();
 
-		h = hsv[0];
+		h = Number.isNaN(hsv[0]) ? h : hsv[0];
 		s = hsv[1] * 100;
 		v = hsv[2] * 100;
 	}
 </script>
 
-<div class={cn("grid w-full gap-4", className)} {...rest}>
+<div class={cn("grid w-full gap-4", className)} data-component="color-picker" {...rest}>
 	<div
-		id="color-picker-well"
 		class="relative aspect-4/3 w-full cursor-crosshair rounded-md border border-muted"
-		style:--color-picker-well-hue={h}
 		role="group"
+		data-slot="color-picker-well"
 		onpointerdown={(event) => {
 			event.preventDefault();
 
 			isDragging = true;
 			handlePointerMove(event);
 		}}
+		style:--color-picker-well-hue={h}
 		bind:this={well}
 	>
 		<div
@@ -91,11 +92,11 @@
 	<Slider.Root
 		class="relative flex h-3 w-full items-center"
 		type="single"
-		step={1}
+		step={0.1}
 		max={360}
 		bind:value={h}
 	>
-		<div id="color-picker-hue" class="relative my-0.5 h-2 w-full grow rounded-full">
+		<div class="relative my-0.5 h-2 w-full grow rounded-full" data-slot="color-picker-hue">
 			<Slider.Range class="absolute w-full" />
 		</div>
 
@@ -105,17 +106,17 @@
 		/>
 	</Slider.Root>
 
-	<Input class="text-xs uppercase shadow-none" type="text" value={hex} onchange={handleChange} />
+	<Input class="text-xs uppercase shadow-none" value={hex} onchange={handleChange} />
 </div>
 
 <style>
-	#color-picker-well {
+	[data-slot="color-picker-well"] {
 		background:
 			linear-gradient(0deg, #000, transparent),
 			linear-gradient(90deg, #fff, hsl(var(--color-picker-well-hue), 100%, 50%));
 	}
 
-	#color-picker-hue {
+	[data-slot="color-picker-hue"] {
 		background: linear-gradient(
 			90deg,
 			#ff0000,

--- a/src/lib/components/ui/Input.svelte
+++ b/src/lib/components/ui/Input.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import type { HTMLInputAttributes } from "svelte/elements";
+	import { cn } from "tailwind-variants";
+	import type { WithElementRef } from "$lib/util";
+
+	type Props = WithElementRef<HTMLInputAttributes>;
+
+	let {
+		class: className,
+		type = "text",
+		value = $bindable(),
+		ref = $bindable(null),
+		...rest
+	}: Props = $props();
+</script>
+
+<input
+	class={cn(
+		"flex h-9 w-full min-w-0 rounded-xl border border-input bg-background px-3 py-1 text-sm shadow-xs ring-offset-background transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 dark:bg-input/30",
+		"focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
+		"aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
+		className,
+	)}
+	{type}
+	data-component="input"
+	{...rest}
+	bind:value
+	bind:this={ref}
+/>

--- a/src/lib/components/ui/Label.svelte
+++ b/src/lib/components/ui/Label.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import { Label } from "bits-ui";
+	import { cn } from "tailwind-variants";
+
+	let { class: className, ref = $bindable(null), ...rest }: Label.RootProps = $props();
+</script>
+
+<Label.Root
+	class={cn(
+		"flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+		className,
+	)}
+	data-component="label"
+	{...rest}
+	bind:ref
+/>

--- a/src/lib/components/ui/Progress.svelte
+++ b/src/lib/components/ui/Progress.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import { Progress, type WithoutChildrenOrChild } from "bits-ui";
+	import { cn } from "tailwind-variants";
+
+	interface Props extends WithoutChildrenOrChild<Progress.RootProps> {
+		indicatorClass?: string;
+	}
+
+	let {
+		class: className,
+		indicatorClass,
+		max = 100,
+		value,
+		ref = $bindable(null),
+		...rest
+	}: Props = $props();
+</script>
+
+<Progress.Root
+	class={cn("relative h-2 w-full overflow-hidden rounded-full bg-primary/20", className)}
+	{value}
+	{max}
+	data-component="progress"
+	{...rest}
+	bind:ref
+>
+	<div
+		class={cn("h-full w-full flex-1 bg-primary transition-transform", indicatorClass)}
+		data-slot="progress-indicator"
+		style:transform="translateX(-{100 - (100 * (value ?? 0)) / (max ?? 1)}%)"
+	></div>
+</Progress.Root>

--- a/src/lib/components/ui/Separator.svelte
+++ b/src/lib/components/ui/Separator.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { Separator as SeparatorPrimitive } from "bits-ui";
+	import { cn } from "tailwind-variants";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		"data-slot": dataSlot = "separator",
+		...restProps
+	}: SeparatorPrimitive.RootProps = $props();
+</script>
+
+<SeparatorPrimitive.Root
+	bind:ref
+	data-slot={dataSlot}
+	class={cn(
+		"shrink-0 bg-border data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
+		className,
+	)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/Switch.svelte
+++ b/src/lib/components/ui/Switch.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import type { HTMLInputAttributes } from "svelte/elements";
+	import { cn } from "tailwind-variants";
+	import type { WithElementRef } from "$lib/util";
+
+	let {
+		class: className,
+		checked = $bindable(false),
+		ref = $bindable(null),
+		...rest
+	}: WithElementRef<HTMLInputAttributes> = $props();
+</script>
+
+<input
+	class={cn(
+		"peer relative inline-flex h-[1.15rem] w-8 shrink-0 cursor-pointer appearance-none items-center rounded-full border border-transparent shadow-xs transition-[background-color,box-shadow] outline-none",
+		"bg-input checked:bg-orange-500 dark:bg-input/80",
+		"focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
+		"disabled:cursor-not-allowed disabled:opacity-50",
+
+		// Thumb
+		"before:pointer-events-none before:block before:size-4 before:translate-x-0 before:rounded-full before:bg-background before:ring-0 before:transition-transform",
+		"checked:before:translate-x-[calc(100%-2px)]",
+		"dark:before:bg-foreground dark:checked:before:bg-primary",
+		className,
+	)}
+	type="checkbox"
+	role="switch"
+	data-component="switch"
+	{...rest}
+	bind:checked
+	bind:this={ref}
+/>

--- a/src/lib/components/ui/Textarea.svelte
+++ b/src/lib/components/ui/Textarea.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import type { HTMLTextareaAttributes } from "svelte/elements";
+	import { cn } from "tailwind-variants";
+	import { type WithElementRef, type WithoutChildren } from "$lib/util";
+
+	let {
+		ref = $bindable(null),
+		value = $bindable(),
+		class: className,
+		"data-slot": dataSlot = "textarea",
+		...restProps
+	}: WithoutChildren<WithElementRef<HTMLTextareaAttributes>> = $props();
+</script>
+
+<textarea
+	bind:this={ref}
+	data-slot={dataSlot}
+	class={cn(
+		"flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+		className,
+	)}
+	bind:value
+	{...restProps}></textarea>

--- a/src/lib/components/ui/button-group/button-group-separator.svelte
+++ b/src/lib/components/ui/button-group/button-group-separator.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { ComponentProps } from "svelte";
 	import { cn } from "tailwind-variants";
-	import { Separator } from "$lib/components/ui/separator/index.js";
+	import Separator from "$lib/components/ui/Separator.svelte";
 
 	let {
 		ref = $bindable(null),

--- a/src/lib/components/ui/field/field-label.svelte
+++ b/src/lib/components/ui/field/field-label.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { ComponentProps } from "svelte";
 	import { cn } from "tailwind-variants";
-	import { Label } from "$lib/components/ui/label/index.js";
+	import Label from "$lib/components/ui/Label.svelte";
 
 	let {
 		ref = $bindable(null),

--- a/src/lib/components/ui/field/field-separator.svelte
+++ b/src/lib/components/ui/field/field-separator.svelte
@@ -2,7 +2,7 @@
 	import type { Snippet } from "svelte";
 	import type { HTMLAttributes } from "svelte/elements";
 	import { cn } from "tailwind-variants";
-	import { Separator } from "$lib/components/ui/separator/index.js";
+	import Separator from "$lib/components/ui/Separator.svelte";
 	import type { WithElementRef } from "$lib/util.js";
 
 	let {

--- a/src/lib/components/ui/input-group/input-group-input.svelte
+++ b/src/lib/components/ui/input-group/input-group-input.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { ComponentProps } from "svelte";
 	import { cn } from "tailwind-variants";
-	import { Input } from "$lib/components/ui/input/index.js";
+	import Input from "$lib/components/ui/Input.svelte";
 
 	let {
 		ref = $bindable(null),
@@ -15,7 +15,7 @@
 	bind:ref
 	data-slot="input-group-control"
 	class={cn(
-		"flex-1 rounded-none border-0 bg-transparent shadow-none focus-visible:ring-0 dark:bg-transparent",
+		"flex-1 rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 disabled:bg-transparent aria-invalid:ring-0 dark:bg-transparent dark:disabled:bg-transparent",
 		className,
 	)}
 	bind:value

--- a/src/lib/components/ui/input-group/input-group-textarea.svelte
+++ b/src/lib/components/ui/input-group/input-group-textarea.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { ComponentProps } from "svelte";
 	import { cn } from "tailwind-variants";
-	import { Textarea } from "$lib/components/ui/textarea/index.js";
+	import Textarea from "$lib/components/ui/Textarea.svelte";
 
 	let {
 		ref = $bindable(null),
@@ -15,7 +15,7 @@
 	bind:ref
 	data-slot="input-group-control"
 	class={cn(
-		"flex-1 resize-none rounded-none border-0 bg-transparent py-3 shadow-none focus-visible:ring-0 dark:bg-transparent",
+		"flex-1 resize-none rounded-none border-0 bg-transparent py-2 shadow-none ring-0 focus-visible:ring-0 disabled:bg-transparent aria-invalid:ring-0 dark:bg-transparent dark:disabled:bg-transparent",
 		className,
 	)}
 	bind:value

--- a/src/lib/components/ui/select/select-separator.svelte
+++ b/src/lib/components/ui/select/select-separator.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { Separator as SeparatorPrimitive } from "bits-ui";
 	import { cn } from "tailwind-variants";
-	import { Separator } from "$lib/components/ui/separator/index.js";
+	import Separator from "$lib/components/ui/Separator.svelte";
 
 	let {
 		ref = $bindable(null),


### PR DESCRIPTION
Input, Textarea, Checkbox, Switch, Progress, Separator, Label and
ColorPicker each collapse into a single file under `ui/`, picking up the
new sizing, focus rings and press states.

The kept shadcn wrappers that compose these (field-label,
field-separator, button-group-separator, select-separator,
input-group-input, input-group-textarea) are repointed at the new files.
Old barrels remain until the cleanup PR.



---

### The stack

Merge bottom-up. Each PR is based on the one above it, and each one
type-checks on its own (`vp run check`, 0 errors).

| # | PR | What |
|---|----|------|
| 1 | #240 | `cn` from tailwind-variants, shadow-plugin, css tokens |
| 2 | #241 | Button restyle + Link |
| 3 | #242 | Slider rebuild |
| 4 | #243 | Dialog / Popover / Tooltip |
| 5 | #244 | Input, Textarea, Checkbox, Switch, Progress, Separator, Label, ColorPicker |
| 6 | #245 | Message components |
| 7 | #246 | `components/stream/` + number-flow |
| 8 | #247 | Kept shadcn wrappers polish |
| 9 | #248 | Settings as a dialog |
| 10 | #249 | Chat, channel views, app shell, data layer |
| 11 | #250 | Drop the orphaned shadcn barrels |

Replaces #207, which was 179 files in one review.

The stack tip is byte-identical to `feat/ui-overhaul-v2` — verified with
`git diff ui/11-cleanup feat/ui-overhaul-v2` (empty).

PRs 2–9 are deliberately **additive**: they add the new component next to
the old one without migrating call sites, so each can be read on its own.
The migrations happen in #249, and #250 deletes what is then unreferenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
