### PR TITLE
feat(message): restyle the message components

### DIFF
--- a/src/lib/components/message/AutoMod.svelte
+++ b/src/lib/components/message/AutoMod.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { UserMessage } from "$lib/models/message/user-message.svelte";
 	import type { AutoModMetadata } from "$lib/twitch/eventsub";
-	import { Button } from "../ui/button";
+	import Button from "../ui/Button.svelte";
 	import Message from "./Message.svelte";
 
 	interface Props {
@@ -36,8 +36,8 @@
 		{#if metadata.category !== "msg_hold"}
 			<div class="flex gap-x-4">
 				<Button
-					class="h-min p-0 text-green-400"
-					variant="link"
+					class="text-green-400"
+					variant="inline"
 					disabled={message.deleted}
 					onclick={() => message.allow()}
 				>
@@ -45,8 +45,8 @@
 				</Button>
 
 				<Button
-					class="h-min p-0 text-destructive"
-					variant="link"
+					class="text-destructive"
+					variant="inline"
 					disabled={message.deleted}
 					onclick={() => message.deny()}
 				>

--- a/src/lib/components/message/Badges.svelte
+++ b/src/lib/components/message/Badges.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { Badge } from "$lib/models/badge";
-	import * as Tooltip from "../ui/tooltip";
+	import Tooltip from "../ui/Tooltip.svelte";
 
 	interface Props {
 		badges: Badge[];
@@ -10,23 +10,17 @@
 </script>
 
 {#each badges as badge (badge.id)}
-	<Tooltip.Root>
-		<Tooltip.Trigger>
-			{#snippet child({ props })}
-				<img
-					{...props}
-					class={["inline-block align-middle", badge.color && "rounded-xs"]}
-					src={badge.imageUrl}
-					alt={badge.description}
-					width="18"
-					height="18"
-					style:background-color={badge.color}
-				/>
-			{/snippet}
-		</Tooltip.Trigger>
+	<img
+		class={["inline-block align-middle", badge.color && "rounded-xs"]}
+		src={badge.imageUrl}
+		alt={badge.description}
+		width="18"
+		height="18"
+		data-slot="tooltip-trigger"
+		style:background-color={badge.color}
+	/>
 
-		<Tooltip.Content class="p-1 text-xs" side="top" sideOffset={4}>
-			{badge.title}
-		</Tooltip.Content>
-	</Tooltip.Root>
+	<Tooltip class="p-1 text-xs" side="top">
+		{badge.title}
+	</Tooltip>
 {/each}

--- a/src/lib/components/message/Content.svelte
+++ b/src/lib/components/message/Content.svelte
@@ -5,9 +5,10 @@
 
 	interface Props {
 		message: UserMessage;
+		nested?: boolean;
 	}
 
-	const { message }: Props = $props();
+	const { message, nested = false }: Props = $props();
 </script>
 
 <p
@@ -33,7 +34,7 @@
 						{node.value}
 					</span>
 				{:else}
-					<User {message} mention={node} />
+					<User {message} mention={node} {nested} />
 				{/if}
 			{/if}
 		{:else if node.type === "cheer"}

--- a/src/lib/components/message/Embed.svelte
+++ b/src/lib/components/message/Embed.svelte
@@ -125,7 +125,7 @@
 
 					<div class="relative">
 						<img
-							class="h-full"
+							class="h-full ring-1 ring-black/10 dark:ring-white/10"
 							src={clip.thumbnailURL}
 							alt={clip.title}
 							decoding="async"

--- a/src/lib/components/message/Highlight.svelte
+++ b/src/lib/components/message/Highlight.svelte
@@ -1,10 +1,4 @@
-<script lang="ts">
-	import type { Snippet } from "svelte";
-	import { cn } from "tailwind-variants";
-	import type { HighlightConfig, HighlightType, KeywordHighlightConfig } from "$lib/settings";
-	import CaseSensitive from "~icons/local/case-sensitive";
-	import Regex from "~icons/local/regex";
-	import WholeWord from "~icons/local/whole-word";
+<script lang="ts" module>
 	import At from "~icons/ph/at";
 	import Highlighter from "~icons/ph/highlighter";
 	import Repeat from "~icons/ph/repeat";
@@ -14,6 +8,27 @@
 	import Star from "~icons/ph/star-fill";
 	import Sword from "~icons/ph/sword";
 	import VideoCamera from "~icons/ph/video-camera";
+
+	export const decorations = {
+		mention: { icon: At, label: "Mention" },
+		new: { icon: Sparkle, label: "First Time Chat" },
+		returning: { icon: Repeat, label: "Returning Chatter" },
+		suspicious: { icon: ShieldWarning, label: "Suspicious User" },
+		broadcaster: { icon: VideoCamera, label: "Broadcaster" },
+		moderator: { icon: Sword, label: "Moderator" },
+		subscriber: { icon: Star, label: "Subscriber" },
+		vip: { icon: SketchLogo, label: "VIP" },
+		custom: { icon: Highlighter, label: "Custom" },
+	};
+</script>
+
+<script lang="ts">
+	import type { Snippet } from "svelte";
+	import { cn } from "tailwind-variants";
+	import type { HighlightConfig, HighlightType, KeywordHighlightConfig } from "$lib/settings";
+	import CaseSensitive from "~icons/local/case-sensitive";
+	import Regex from "~icons/local/regex";
+	import WholeWord from "~icons/local/whole-word";
 
 	type Props = {
 		children: Snippet;
@@ -32,18 +47,6 @@
 	);
 
 	const { children, class: className, type, config, info }: Props = $props();
-
-	const decorations = {
-		mention: { icon: At, label: "Mention" },
-		new: { icon: Sparkle, label: "First Time Chat" },
-		returning: { icon: Repeat, label: "Returning Chatter" },
-		suspicious: { icon: ShieldWarning, label: "Suspicious User" },
-		broadcaster: { icon: VideoCamera, label: "Broadcaster" },
-		moderator: { icon: Sword, label: "Moderator" },
-		subscriber: { icon: Star, label: "Subscriber" },
-		vip: { icon: SketchLogo, label: "VIP" },
-		custom: { icon: Highlighter, label: "Custom" },
-	};
 
 	const decoration = $derived(decorations[type]);
 </script>

--- a/src/lib/components/message/Message.svelte
+++ b/src/lib/components/message/Message.svelte
@@ -30,7 +30,7 @@
 <Timestamp date={message.timestamp} />
 <Badges badges={message.badges} />
 <User {message} {nested} />
-<Content {message} />
+<Content {message} {nested} />
 
 {#if settings.state["chat.embeds"] && !nested && linkNodes.some(canEmbed)}
 	<div class="mt-2 flex gap-2">

--- a/src/lib/components/message/QuickActions.svelte
+++ b/src/lib/components/message/QuickActions.svelte
@@ -6,9 +6,9 @@
 	import Clock from "~icons/ph/clock";
 	import Gavel from "~icons/ph/gavel";
 	import Trash from "~icons/ph/trash";
-	import { Button } from "../ui/button";
 	import * as ButtonGroup from "../ui/button-group";
-	import * as Tooltip from "../ui/tooltip";
+	import Button from "../ui/Button.svelte";
+	import Tooltip from "../ui/Tooltip.svelte";
 
 	interface Props {
 		class?: string;
@@ -61,24 +61,16 @@
 </ButtonGroup.Root>
 
 {#snippet button(props: ComponentProps<typeof Button> & { icon: Component; tooltip: string })}
-	<Tooltip.Root>
-		<Tooltip.Trigger>
-			{#snippet child({ props: childProps })}
-				<Button
-					{...props}
-					{...childProps}
-					size="icon-sm"
-					variant="secondary"
-					aria-label={props.tooltip}
-					onclick={props.onclick}
-				>
-					<props.icon />
-				</Button>
-			{/snippet}
-		</Tooltip.Trigger>
+	<Button
+		{...props}
+		size="icon-sm"
+		variant="secondary"
+		data-slot="tooltip-trigger"
+		aria-label={props.tooltip}
+		onclick={props.onclick}
+	>
+		<props.icon />
+	</Button>
 
-		<Tooltip.Content side="top">
-			{props.tooltip}
-		</Tooltip.Content>
-	</Tooltip.Root>
+	<Tooltip side="top">{props.tooltip}</Tooltip>
 {/snippet}

--- a/src/lib/components/message/events/Banned.svelte
+++ b/src/lib/components/message/events/Banned.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { Channel } from "$lib/models/channel.svelte";
 	import { colorizeName } from "$lib/util";
-	import { Button } from "../../ui/button";
+	import Button from "../../ui/Button.svelte";
 
 	interface Props {
 		channel: Channel;
@@ -12,4 +12,4 @@
 
 You are permanently banned from {@html colorizeName(channel.user)} and cannot send messages. If you have
 been unbanned, try
-<Button class="h-min p-0" variant="link" onclick={() => channel.rejoin()}>rejoining</Button>.
+<Button variant="inline" onclick={() => channel.rejoin()}>rejoining</Button>.


### PR DESCRIPTION
Badges, content, highlights, quick actions, automod and the event rows
move onto the new primitives and spacing scale.



---

### The stack

Merge bottom-up. Each PR is based on the one above it, and each one
type-checks on its own (`vp run check`, 0 errors).

| # | PR | What |
|---|----|------|
| 1 | #240 | `cn` from tailwind-variants, shadow-plugin, css tokens |
| 2 | #241 | Button restyle + Link |
| 3 | #242 | Slider rebuild |
| 4 | #243 | Dialog / Popover / Tooltip |
| 5 | #244 | Input, Textarea, Checkbox, Switch, Progress, Separator, Label, ColorPicker |
| 6 | #245 | Message components |
| 7 | #246 | `components/stream/` + number-flow |
| 8 | #247 | Kept shadcn wrappers polish |
| 9 | #248 | Settings as a dialog |
| 10 | #249 | Chat, channel views, app shell, data layer |
| 11 | #250 | Drop the orphaned shadcn barrels |

Replaces #207, which was 179 files in one review.

The stack tip is byte-identical to `feat/ui-overhaul-v2` — verified with
`git diff ui/11-cleanup feat/ui-overhaul-v2` (empty).

PRs 2–9 are deliberately **additive**: they add the new component next to
the old one without migrating call sites, so each can be read on its own.
The migrations happen in #249, and #250 deletes what is then unreferenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
