### PR TITLE
feat(stream): group the stream components and animate viewer counts

### DIFF
--- a/src/lib/components/stream/GuestList.svelte
+++ b/src/lib/components/stream/GuestList.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+	import type { Channel } from "$lib/models/channel.svelte";
+	import type { Guest } from "$lib/models/stream.svelte";
+	import Users from "~icons/ph/users-bold";
+	import Button from "../ui/Button.svelte";
+	import Popover from "../ui/Popover.svelte";
+
+	interface Props {
+		tooltip?: boolean;
+		channel: Channel;
+	}
+
+	const { tooltip = false, channel }: Props = $props();
+
+	// This was already checked in <TitleBar />
+	const stream = $derived(channel.stream!);
+</script>
+
+{#if tooltip}
+	{@render content()}
+{:else}
+	<Button
+		class="size-min p-1 text-xs"
+		size="sm"
+		variant="ghost"
+		popovertarget="guest-list-{channel.id}"
+		aria-label="View guests"
+	>
+		+{stream.guests.size}
+	</Button>
+
+	<Popover id="guest-list-{channel.id}" class="w-fit">
+		{@render content()}
+	</Popover>
+{/if}
+
+{#snippet content()}
+	{#if !tooltip}
+		{@render participant(channel.user, stream.viewers)}
+	{/if}
+
+	<span
+		class={[
+			"mb-1 inline-block text-xs font-medium text-muted-foreground uppercase",
+			tooltip ? "mt-2" : "mt-4",
+		]}
+	>
+		Live with
+	</span>
+
+	<ul class="flex flex-col gap-y-1">
+		{#each stream.guests as [id, guest] (id)}
+			<li>
+				{@render participant(guest, guest.viewers)}
+			</li>
+		{/each}
+	</ul>
+{/snippet}
+
+{#snippet participant(guest: Omit<Guest, "viewers">, viewers: number | null)}
+	<div class="flex items-center justify-between gap-x-8">
+		<div class={["flex items-center", tooltip ? "gap-x-1 text-xs" : "gap-x-2 text-sm"]}>
+			<img
+				src={guest.avatarUrl}
+				alt={guest.displayName}
+				class={[
+					"rounded-full ring-1 ring-black/10 dark:ring-white/10",
+					tooltip ? "size-5" : "size-6",
+				]}
+				width="50"
+				height="50"
+			/>
+
+			<span
+				class="font-medium"
+				style:color={tooltip ? "var(--color-text-primary-foreground)" : guest.color}
+			>
+				{guest.displayName}
+			</span>
+		</div>
+
+		{#if viewers != null}
+			<div class="flex items-center text-xs text-red-400 tabular-nums dark:text-red-500">
+				<Users class="mr-1" />
+				{viewers}
+			</div>
+		{/if}
+	</div>
+{/snippet}

--- a/src/lib/components/stream/StreamHeader.svelte
+++ b/src/lib/components/stream/StreamHeader.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+	import NumberFlow from "@number-flow/svelte";
+	import dayjs from "dayjs";
+	import duration from "dayjs/plugin/duration";
+	import { onDestroy } from "svelte";
+	import type { Stream } from "$lib/models/stream.svelte";
+	import Clock from "~icons/ph/clock";
+	import Users from "~icons/ph/users";
+
+	dayjs.extend(duration);
+
+	interface Props {
+		stream: Stream;
+	}
+
+	const { stream }: Props = $props();
+
+	let uptime = $state(getUptime());
+
+	let interval: ReturnType<typeof setInterval> | undefined;
+
+	const timeout = setTimeout(() => {
+		interval = setInterval(() => {
+			uptime = getUptime();
+		}, 1000);
+	}, 1000 - new Date().getMilliseconds());
+
+	onDestroy(() => {
+		clearTimeout(timeout);
+		clearInterval(interval);
+	});
+
+	function getUptime() {
+		const diff = dayjs.duration(dayjs().diff(dayjs(stream.createdAt)));
+		const hours = Math.floor(diff.asHours()).toString().padStart(2, "0");
+
+		return `${hours}:${diff.format("mm:ss")}`;
+	}
+</script>
+
+<div
+	class="flex items-center justify-between overflow-hidden border-b p-2 text-xs text-muted-foreground shadow"
+>
+	<p class="truncate" title={stream.title}>{stream.title}</p>
+
+	<div class="ml-[3ch] flex items-center gap-x-2.5">
+		<div class="flex items-center">
+			<Users class="mr-1" />
+			<NumberFlow class="tabular-nums" value={stream.viewers} />
+		</div>
+
+		<div class="flex items-center">
+			<Clock class="mr-1" />
+			<span class="tabular-nums">{uptime}</span>
+		</div>
+	</div>
+</div>

--- a/src/lib/components/stream/StreamInfo.svelte
+++ b/src/lib/components/stream/StreamInfo.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import { useSidebar } from "$lib/hooks/use-sidebar.svelte";
+	import type { Channel } from "$lib/models/channel.svelte";
+	import DotsThreeCircle from "~icons/ph/dots-three-circle";
+
+	interface Props {
+		channel: Channel;
+	}
+
+	const { channel }: Props = $props();
+
+	const sidebar = useSidebar();
+</script>
+
+<img
+	class={[
+		"ease size-8 rounded-full object-cover ring-1 ring-black/10 transition-opacity duration-200 dark:ring-white/10",
+		sidebar.collapsed && "opacity-0",
+		!channel.stream && "grayscale",
+	]}
+	src={channel.user.avatarUrl}
+	alt={channel.user.displayName}
+	width="150"
+	height="150"
+	draggable="false"
+/>
+
+{#if !sidebar.collapsed && channel.stream?.guests.size}
+	<div
+		class="absolute right-1 bottom-1 flex items-center justify-center rounded-full bg-muted/70"
+	>
+		<DotsThreeCircle class="size-5" />
+	</div>
+{/if}

--- a/src/lib/components/stream/StreamTooltip.svelte
+++ b/src/lib/components/stream/StreamTooltip.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+	import NumberFlow from "@number-flow/svelte";
+	import { app } from "$lib/app.svelte";
+	import { useSidebar } from "$lib/hooks/use-sidebar.svelte";
+	import { createChannelMenu } from "$lib/menus/channel-menu";
+	import type { Channel } from "$lib/models/channel.svelte";
+	import { openMenu } from "$lib/util";
+	import ClockCountdown from "~icons/ph/clock-countdown";
+	import PushPin from "~icons/ph/push-pin";
+	import Users from "~icons/ph/users-bold";
+	import Tooltip from "../ui/Tooltip.svelte";
+	import GuestList from "./GuestList.svelte";
+	import StreamInfo from "./StreamInfo.svelte";
+
+	interface Props {
+		channel: Channel;
+	}
+
+	const { channel }: Props = $props();
+
+	const sidebar = useSidebar();
+</script>
+
+{#snippet indicators()}
+	{#if channel.pinned}
+		<PushPin />
+	{/if}
+
+	{#if channel.ephemeral}
+		<ClockCountdown />
+	{/if}
+{/snippet}
+
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+	class="relative flex cursor-pointer items-center gap-2 p-2 transition-colors hover:bg-accent"
+	onclick={async () => {
+		await app.open(channel);
+		app.history.pushChannel(channel.id);
+	}}
+	oncontextmenu={(event) => openMenu(event, () => createChannelMenu(channel))}
+	data-slot="tooltip-trigger"
+>
+	<StreamInfo {channel} />
+</div>
+
+<Tooltip class="max-w-64" side="right" delay={0}>
+	{#if channel.stream}
+		<div class="space-y-0.5">
+			{#if !sidebar.collapsed}
+				<div class="flex items-center gap-1">
+					{@render indicators()}
+
+					<div
+						class="overflow-hidden text-ellipsis whitespace-nowrap text-twitch dark:text-twitch-link"
+					>
+						{channel.user.displayName} &bullet; {channel.stream.game}
+					</div>
+				</div>
+			{/if}
+
+			<p class="line-clamp-2">{channel.stream.title}</p>
+
+			{#if !sidebar.collapsed}
+				<div class="flex items-center text-red-500 dark:text-red-400">
+					<Users class="mr-1 size-3" />
+
+					<p class="text-xs">
+						<NumberFlow class="tabular-nums" value={channel.stream.viewers} /> viewers
+					</p>
+				</div>
+			{/if}
+
+			{#if channel.stream.guests.size}
+				<GuestList {channel} tooltip />
+			{/if}
+		</div>
+	{:else if !sidebar.collapsed}
+		<div class="flex items-center gap-1">
+			{@render indicators()}
+			{channel.user.displayName}
+		</div>
+	{/if}
+</Tooltip>


### PR DESCRIPTION
Adds StreamHeader, StreamInfo, StreamTooltip and GuestList under
`components/stream/` and animates volatile numbers with number-flow.

Additive: the old top-level copies still serve their consumers until the
cleanup PR at the end of the stack.



---

### The stack

Merge bottom-up. Each PR is based on the one above it, and each one
type-checks on its own (`vp run check`, 0 errors).

| # | PR | What |
|---|----|------|
| 1 | #240 | `cn` from tailwind-variants, shadow-plugin, css tokens |
| 2 | #241 | Button restyle + Link |
| 3 | #242 | Slider rebuild |
| 4 | #243 | Dialog / Popover / Tooltip |
| 5 | #244 | Input, Textarea, Checkbox, Switch, Progress, Separator, Label, ColorPicker |
| 6 | #245 | Message components |
| 7 | #246 | `components/stream/` + number-flow |
| 8 | #247 | Kept shadcn wrappers polish |
| 9 | #248 | Settings as a dialog |
| 10 | #249 | Chat, channel views, app shell, data layer |
| 11 | #250 | Drop the orphaned shadcn barrels |

Replaces #207, which was 179 files in one review.

The stack tip is byte-identical to `feat/ui-overhaul-v2` — verified with
`git diff ui/11-cleanup feat/ui-overhaul-v2` (empty).

PRs 2–9 are deliberately **additive**: they add the new component next to
the old one without migrating call sites, so each can be read on its own.
The migrations happen in #249, and #250 deletes what is then unreferenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
