### PR TITLE
chore(ui): polish the kept shadcn wrappers

### DIFF
--- a/src/lib/components/ui/field/field-description.svelte
+++ b/src/lib/components/ui/field/field-description.svelte
@@ -15,7 +15,7 @@
 	bind:this={ref}
 	data-slot="field-description"
 	class={cn(
-		"text-sm leading-normal font-normal text-muted-foreground group-has-[[data-orientation=horizontal]]/field:text-balance",
+		"text-sm leading-normal font-normal text-muted-foreground",
 		"last:mt-0 nth-last-2:-mt-1 [[data-variant=legend]+&]:-mt-1.5",
 		"[&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
 		className,

--- a/src/lib/components/ui/field/field-group.svelte
+++ b/src/lib/components/ui/field/field-group.svelte
@@ -15,7 +15,7 @@
 	bind:this={ref}
 	data-slot="field-group"
 	class={cn(
-		"group/field-group @container/field-group flex w-full flex-col gap-7 data-[slot=checkbox-group]:gap-3 [&>[data-slot=field-group]]:gap-4",
+		"group/field-group @container/field-group flex w-full flex-col gap-6 data-[slot=checkbox-group]:gap-3 *:data-[slot=field-group]:gap-4",
 		className,
 	)}
 	{...restProps}

--- a/src/lib/components/ui/field/field-legend.svelte
+++ b/src/lib/components/ui/field/field-legend.svelte
@@ -18,12 +18,7 @@
 	bind:this={ref}
 	data-slot="field-legend"
 	data-variant={variant}
-	class={cn(
-		"mb-3 font-medium",
-		"data-[variant=legend]:text-base",
-		"data-[variant=label]:text-sm",
-		className,
-	)}
+	class={cn("mb-3 text-lg font-medium", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/src/lib/components/ui/input-group/index.ts
+++ b/src/lib/components/ui/input-group/index.ts
@@ -6,9 +6,12 @@ import Textarea from "./input-group-textarea.svelte";
 import Root from "./input-group.svelte";
 
 export {
+	Root,
 	Addon,
 	Button,
 	Input,
+	Text,
+	Textarea,
 	//
 	Root as InputGroup,
 	Addon as InputGroupAddon,
@@ -16,7 +19,4 @@ export {
 	Input as InputGroupInput,
 	Text as InputGroupText,
 	Textarea as InputGroupTextarea,
-	Root,
-	Text,
-	Textarea,
 };

--- a/src/lib/components/ui/input-group/input-group-addon.svelte
+++ b/src/lib/components/ui/input-group/input-group-addon.svelte
@@ -1,18 +1,17 @@
 <script lang="ts" module>
-	import type { VariantProps } from "tailwind-variants";
-	import { tv } from "tailwind-variants/lite";
+	import { tv, type VariantProps } from "tailwind-variants/lite";
+
 	export const inputGroupAddonVariants = tv({
-		base: "text-muted-foreground flex h-auto cursor-text select-none items-center justify-center gap-2 py-1.5 text-sm font-medium group-data-[disabled=true]/input-group:opacity-50 [&>kbd]:rounded-[calc(var(--radius)-5px)] [&>svg:not([class*='size-'])]:size-4",
+		base: "text-muted-foreground h-auto gap-2 py-1.5 text-sm font-medium group-data-[disabled=true]/input-group:opacity-50 [&>kbd]:rounded-[calc(var(--radius)-5px)] [&>svg:not([class*='size-'])]:size-4 flex cursor-text items-center justify-center select-none",
 		variants: {
 			align: {
 				"inline-start":
-					"order-first ps-3 has-[>button]:ms-[-0.45rem] has-[>kbd]:ms-[-0.35rem]",
-				"inline-end":
-					"order-last pe-3 has-[>button]:me-[-0.45rem] has-[>kbd]:me-[-0.35rem]",
+					"pl-2 has-[>button]:ml-[-0.3rem] has-[>kbd]:ml-[-0.15rem] order-first",
+				"inline-end": "pr-2 has-[>button]:mr-[-0.3rem] has-[>kbd]:mr-[-0.15rem] order-last",
 				"block-start":
-					"[.border-b]:pb-3 order-first w-full justify-start px-3 pt-3 group-has-[>input]/input-group:pt-2.5",
+					"px-2.5 pt-2 group-has-[>input]/input-group:pt-2 [.border-b]:pb-2 order-first w-full justify-start",
 				"block-end":
-					"[.border-t]:pt-3 order-last w-full justify-start px-3 pb-3 group-has-[>input]/input-group:pb-2.5",
+					"px-2.5 pb-2 group-has-[>input]/input-group:pb-2 [.border-t]:pt-2 order-last w-full justify-start",
 			},
 		},
 		defaultVariants: {
@@ -26,7 +25,7 @@
 <script lang="ts">
 	import type { HTMLAttributes } from "svelte/elements";
 	import { cn } from "tailwind-variants";
-	import type { WithElementRef } from "$lib/util.js";
+	import { type WithElementRef } from "$lib/util.js";
 
 	let {
 		ref = $bindable(null),

--- a/src/lib/components/ui/input-group/input-group-text.svelte
+++ b/src/lib/components/ui/input-group/input-group-text.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { HTMLAttributes } from "svelte/elements";
 	import { cn } from "tailwind-variants";
-	import type { WithElementRef } from "$lib/util.js";
+	import { type WithElementRef } from "$lib/util.js";
 
 	let {
 		ref = $bindable(null),

--- a/src/lib/components/ui/input-group/input-group.svelte
+++ b/src/lib/components/ui/input-group/input-group.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { HTMLAttributes } from "svelte/elements";
 	import { cn } from "tailwind-variants";
-	import type { WithElementRef } from "$lib/util.js";
+	import { type WithElementRef } from "$lib/util.js";
 
 	let {
 		ref = $bindable(null),
@@ -16,21 +16,7 @@
 	data-slot="input-group"
 	role="group"
 	class={cn(
-		"group/input-group relative flex w-full items-center rounded-md border border-input shadow-xs transition-[color,box-shadow] outline-none dark:bg-input/30",
-		"h-9 has-[>textarea]:h-auto",
-
-		// Variants based on alignment.
-		"has-[>[data-align=inline-start]]:[&>input]:ps-2",
-		"has-[>[data-align=inline-end]]:[&>input]:pe-2",
-		"has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-start]]:[&>input]:pb-3",
-		"has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3",
-
-		// Focus state.
-		"has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-[3px] has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50",
-
-		// Error state.
-		"has-[[data-slot][aria-invalid=true]]:border-destructive has-[[data-slot][aria-invalid=true]]:ring-destructive/20 dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40",
-
+		"group/input-group relative flex h-8 w-full min-w-0 items-center rounded-xl border border-input transition-colors outline-none in-data-[slot=combobox-content]:focus-within:border-inherit in-data-[slot=combobox-content]:focus-within:ring-0 has-disabled:bg-input/50 has-disabled:opacity-50 has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-3 has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot][aria-invalid=true]]:border-destructive has-[[data-slot][aria-invalid=true]]:ring-3 has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>textarea]:h-auto dark:bg-input/30 dark:has-disabled:bg-input/80 dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40 has-[>[data-align=block-end]]:[&>input]:pt-3 has-[>[data-align=block-start]]:[&>input]:pb-3 has-[>[data-align=inline-end]]:[&>input]:pr-1.5 has-[>[data-align=inline-start]]:[&>input]:pl-1.5",
 		className,
 	)}
 	{...props}

--- a/src/lib/components/ui/native-select/native-select.svelte
+++ b/src/lib/components/ui/native-select/native-select.svelte
@@ -31,7 +31,7 @@
 		bind:this={ref}
 		data-slot="native-select"
 		data-size={size}
-		class="h-8 w-full min-w-0 appearance-none rounded-lg border border-input bg-transparent py-1 pr-8 pl-2.5 text-sm transition-colors outline-none select-none selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] data-[size=sm]:py-0.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40"
+		class="h-9 w-full min-w-0 appearance-none rounded-xl border border-input bg-transparent py-1 pr-8 pl-2.5 text-sm transition-colors outline-none select-none selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] data-[size=sm]:py-0.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40"
 		{...restProps}
 	>
 		{@render children?.()}

--- a/src/lib/components/ui/select/select-content.svelte
+++ b/src/lib/components/ui/select/select-content.svelte
@@ -25,7 +25,7 @@
 		{preventScroll}
 		data-slot="select-content"
 		class={cn(
-			"relative z-50 max-h-(--bits-select-content-available-height) min-w-[8rem] origin-(--bits-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:translate-y-1 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:-translate-x-1 data-[side=left]:slide-in-from-end-2 data-[side=right]:translate-x-1 data-[side=right]:slide-in-from-start-2 data-[side=top]:-translate-y-1 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+			"relative z-50 max-h-(--bits-select-content-available-height) min-w-[8rem] origin-(--bits-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md bg-popover text-popover-foreground smooth-shadow-ring-md data-[side=bottom]:translate-y-1 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:-translate-x-1 data-[side=left]:slide-in-from-end-2 data-[side=right]:translate-x-1 data-[side=right]:slide-in-from-start-2 data-[side=top]:-translate-y-1 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
 			className,
 		)}
 		{...restProps}


### PR DESCRIPTION
Spacing, focus and variant fixes across the field, input-group,
native-select, select, empty, button-group and radio-group wrappers.
These stay as multi-file barrels; only their styles change.



---

### The stack

Merge bottom-up. Each PR is based on the one above it, and each one
type-checks on its own (`vp run check`, 0 errors).

| # | PR | What |
|---|----|------|
| 1 | #240 | `cn` from tailwind-variants, shadow-plugin, css tokens |
| 2 | #241 | Button restyle + Link |
| 3 | #242 | Slider rebuild |
| 4 | #243 | Dialog / Popover / Tooltip |
| 5 | #244 | Input, Textarea, Checkbox, Switch, Progress, Separator, Label, ColorPicker |
| 6 | #245 | Message components |
| 7 | #246 | `components/stream/` + number-flow |
| 8 | #247 | Kept shadcn wrappers polish |
| 9 | #248 | Settings as a dialog |
| 10 | #249 | Chat, channel views, app shell, data layer |
| 11 | #250 | Drop the orphaned shadcn barrels |

Replaces #207, which was 179 files in one review.

The stack tip is byte-identical to `feat/ui-overhaul-v2` — verified with
`git diff ui/11-cleanup feat/ui-overhaul-v2` (empty).

PRs 2–9 are deliberately **additive**: they add the new component next to
the old one without migrating call sites, so each can be read on its own.
The migrations happen in #249, and #250 deletes what is then unreferenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
