### PR TITLE
refactor(settings): rebuild settings as a dialog

### DIFF
--- a/src/lib/components/settings/Category.svelte
+++ b/src/lib/components/settings/Category.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+	import * as Empty from "$lib/components/ui/empty";
+	import MagnifyingGlass from "~icons/ph/magnifying-glass";
+	import FieldControl from "./FieldControl.svelte";
+	import type { SettingsCategory } from "./types";
+
+	interface Props {
+		category: SettingsCategory;
+		query?: string;
+	}
+
+	const { category, query = "" }: Props = $props();
+</script>
+
+<div class="space-y-6">
+	<header class="flex items-center gap-3">
+		<div
+			class="flex size-9 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground"
+		>
+			<category.icon />
+		</div>
+
+		<div>
+			<h2 class="text-lg leading-tight font-semibold">{category.label}</h2>
+
+			{#if query}
+				<p class="text-sm text-muted-foreground">Matching "{query}"</p>
+			{/if}
+		</div>
+	</header>
+
+	{#if category.fields.length === 0}
+		<Empty.Root class="border">
+			<Empty.Header>
+				<Empty.Media variant="icon">
+					<MagnifyingGlass />
+				</Empty.Media>
+
+				<Empty.Title>No settings found</Empty.Title>
+
+				<Empty.Description>
+					Nothing in {category.label} matches "{query}". Try a different search.
+				</Empty.Description>
+			</Empty.Header>
+		</Empty.Root>
+	{:else}
+		<div class="space-y-6 divide-y divide-border *:pb-6">
+			{#each category.fields as field, i (i)}
+				<FieldControl {field} />
+			{/each}
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/settings/FieldControl.svelte
+++ b/src/lib/components/settings/FieldControl.svelte
@@ -1,0 +1,148 @@
+<script lang="ts">
+	import * as Field from "$lib/components/ui/field";
+	import Input from "$lib/components/ui/Input.svelte";
+	import * as NativeSelect from "$lib/components/ui/native-select";
+	import * as RadioGroup from "$lib/components/ui/radio-group";
+	import Slider from "$lib/components/ui/Slider.svelte";
+	import Switch from "$lib/components/ui/Switch.svelte";
+	import { settings } from "$lib/settings";
+	import FieldControl from "./FieldControl.svelte";
+	import type { BaseField, SettingsField } from "./types";
+
+	interface Props {
+		field: SettingsField;
+	}
+
+	const { field }: Props = $props();
+</script>
+
+{#if field.type === "group"}
+	<Field.Set>
+		{#if field.label}
+			<Field.Legend>{field.label}</Field.Legend>
+		{/if}
+
+		<Field.Group>
+			{#each field.fields as subField}
+				<FieldControl field={subField} />
+			{/each}
+		</Field.Group>
+	</Field.Set>
+{:else if field.type === "custom"}
+	{#if field.renderAs === "field"}
+		<Field.Field>
+			{@render content(field)}
+
+			<field.component />
+		</Field.Field>
+	{:else}
+		<Field.Set>
+			<Field.Legend>{field.label}</Field.Legend>
+
+			{@render description(field.description)}
+
+			<field.component />
+		</Field.Set>
+	{/if}
+{:else if field.type === "input"}
+	<Field.Field>
+		<Field.Label for={field.id}>{field.label}</Field.Label>
+
+		<Input
+			id={field.id}
+			class="max-w-1/2"
+			autocapitalize="off"
+			autocomplete="off"
+			disabled={field.disabled?.()}
+			placeholder={field.placeholder}
+			bind:value={settings.state[field.id]}
+		/>
+
+		{@render description(field.description)}
+	</Field.Field>
+{:else if field.type === "radio"}
+	<Field.Set>
+		{@render content(field)}
+
+		<RadioGroup.Root
+			id={field.id}
+			disabled={field.disabled?.()}
+			bind:value={settings.state[field.id]}
+		>
+			{#each field.items as option (option.value)}
+				<Field.Field class={[option.description && "items-start"]} orientation="horizontal">
+					<RadioGroup.Item
+						class={[option.description && "mt-0.5"]}
+						value={option.value}
+					/>
+
+					<Field.Label aria-disabled={field.disabled?.()}>
+						<Field.Content>
+							{option.label}
+
+							{@render description(option.description)}
+						</Field.Content>
+					</Field.Label>
+				</Field.Field>
+			{/each}
+		</RadioGroup.Root>
+	</Field.Set>
+{:else if field.type === "select"}
+	<Field.Field>
+		<Field.Label for={field.id}>{field.label}</Field.Label>
+
+		<div class="max-w-52 *:data-[slot=native-select-wrapper]:w-full">
+			<NativeSelect.Root bind:value={settings.state[field.id]}>
+				{#each field.items as item (item.value)}
+					<NativeSelect.Option value={item.value}>
+						{item.label}
+					</NativeSelect.Option>
+				{/each}
+			</NativeSelect.Root>
+		</div>
+
+		{@render description(field.description)}
+	</Field.Field>
+{:else if field.type === "slider"}
+	<Field.Field>
+		{@render content(field)}
+
+		<Slider
+			id={field.id}
+			type="single"
+			formatValue={field.formatValue}
+			showSteps={field.showSteps}
+			min={field.min}
+			max={field.max}
+			step={field.step}
+			disabled={field.disabled?.()}
+			bind:value={settings.state[field.id]}
+		/>
+	</Field.Field>
+{:else if field.type === "switch"}
+	<Field.Field orientation="horizontal">
+		{@render content(field)}
+
+		<Switch
+			id={field.id}
+			onchange={(event) => field.onchange?.(event.currentTarget.checked)}
+			bind:checked={settings.state[field.id]}
+		/>
+	</Field.Field>
+{/if}
+
+{#snippet description(description?: string)}
+	{#if description}
+		<Field.Description>
+			{@html description}
+		</Field.Description>
+	{/if}
+{/snippet}
+
+{#snippet content(field: BaseField)}
+	<Field.Content>
+		<Field.Label for={field.id}>{field.label}</Field.Label>
+
+		{@render description(field.description)}
+	</Field.Content>
+{/snippet}

--- a/src/lib/components/settings/SettingsDialog.svelte
+++ b/src/lib/components/settings/SettingsDialog.svelte
@@ -1,0 +1,200 @@
+<script module lang="ts">
+	export const settingsDialogId = "settings-dialog";
+
+	export function openSettings() {
+		document.querySelector<HTMLDialogElement>(`#${settingsDialogId}`)?.showModal();
+	}
+
+	export function closeSettings() {
+		document.querySelector<HTMLDialogElement>(`#${settingsDialogId}`)?.close();
+	}
+</script>
+
+<script lang="ts">
+	import { Tabs } from "bits-ui";
+	import Button from "$lib/components/ui/Button.svelte";
+	import Dialog from "$lib/components/ui/Dialog.svelte";
+	import * as InputGroup from "$lib/components/ui/input-group";
+	import Separator from "$lib/components/ui/Separator.svelte";
+	import { log } from "$lib/log";
+	import { settings } from "$lib/settings";
+	import MagnifyingGlass from "~icons/ph/magnifying-glass";
+	import X from "~icons/ph/x";
+	import Category from "./Category.svelte";
+	import { countFields, filterCategory } from "./search";
+	import SidebarActions from "./SidebarActions.svelte";
+	import type { SettingsCategory } from "./types";
+
+	const imports = import.meta.glob<SettingsCategory>(["./categories/*.ts"], {
+		eager: true,
+		import: "default",
+	});
+
+	const categories = Object.values(imports).toSorted((a, b) => a.order - b.order);
+
+	let query = $state("");
+	let active = $state(categories[0].label);
+	let searchRef = $state<HTMLInputElement | null>(null);
+
+	const searching = $derived(query.trim().length > 0);
+	const results = $derived(categories.map((category) => filterCategory(category, query)));
+	const counts = $derived(
+		new Map(results.map((category) => [category.label, countFields(category.fields)])),
+	);
+	const total = $derived(results.reduce((sum, { fields }) => sum + countFields(fields), 0));
+
+	// Keep the selection on a category that still has something to show
+	$effect(() => {
+		if (!searching || counts.get(active)) return;
+
+		const first = results.find((category) => counts.get(category.label));
+
+		if (first) {
+			active = first.label;
+		}
+	});
+
+	function onkeydown(event: KeyboardEvent) {
+		if (event.key === "f" && (event.ctrlKey || event.metaKey)) {
+			event.preventDefault();
+			searchRef?.focus();
+			searchRef?.select();
+		}
+	}
+
+	function clearSearch() {
+		query = "";
+		searchRef?.focus();
+	}
+
+	async function onclose() {
+		await settings.saveNow();
+		log.info("Settings saved");
+	}
+</script>
+
+<Dialog
+	id={settingsDialogId}
+	class="m-0 h-screen max-h-none max-w-none! overflow-hidden rounded-none p-0 *:data-[slot=dialog-content]:h-full *:data-[slot=dialog-content]:space-y-0"
+	aria-label="Settings"
+	{onkeydown}
+	{onclose}
+>
+	<Tabs.Root
+		id="settings-tabs"
+		class="flex h-full overflow-hidden"
+		orientation="vertical"
+		bind:value={active}
+	>
+		<div class="flex h-full w-52 shrink-0 flex-col gap-3 p-3">
+			<InputGroup.Root class="h-9 bg-background">
+				<InputGroup.Addon>
+					<MagnifyingGlass />
+				</InputGroup.Addon>
+
+				<InputGroup.Input
+					placeholder="Search settings"
+					aria-label="Search settings"
+					autocapitalize="off"
+					autocomplete="off"
+					spellcheck={false}
+					bind:ref={searchRef}
+					bind:value={query}
+					onkeydown={(event) => {
+						if (event.key === "Escape" && searching) {
+							event.stopPropagation();
+							event.preventDefault();
+							clearSearch();
+						}
+					}}
+				/>
+
+				{#if searching}
+					<InputGroup.Addon align="inline-end">
+						<InputGroup.Button
+							size="icon-xs"
+							aria-label="Clear search"
+							onclick={clearSearch}
+						>
+							<X />
+						</InputGroup.Button>
+					</InputGroup.Addon>
+				{/if}
+			</InputGroup.Root>
+
+			<Tabs.List class="min-h-0 flex-1 space-y-0.5 overflow-y-auto">
+				{#each results as category (category.label)}
+					{@const count = counts.get(category.label) ?? 0}
+
+					<Tabs.Trigger value={category.label} disabled={searching && count === 0}>
+						{#snippet child({ props })}
+							<Button
+								class="w-full justify-start text-muted-foreground hover:bg-accent/50 data-[state=active]:bg-muted data-[state=active]:text-foreground data-[state=active]:shadow-xs"
+								variant="ghost"
+								{...props}
+							>
+								<category.icon />
+
+								<span class="truncate">{category.label}</span>
+
+								{#if searching}
+									<span
+										class="ml-auto rounded-full bg-primary/20 px-1.5 text-xs tabular-nums"
+									>
+										{count}
+									</span>
+								{/if}
+							</Button>
+						{/snippet}
+					</Tabs.Trigger>
+				{/each}
+			</Tabs.List>
+
+			<Separator />
+
+			<SidebarActions />
+		</div>
+
+		<div class="relative flex min-w-0 grow flex-col border-l bg-accent/15">
+			<div
+				class="flex items-center justify-end gap-2 px-4 pt-3 text-sm text-muted-foreground"
+			>
+				<div class="mr-auto">
+					Settings
+
+					{#if searching}
+						&bullet;
+
+						<span class="tabular-nums">
+							{total}
+							{total === 1 ? "result" : "results"}
+						</span>
+					{/if}
+				</div>
+
+				<Button
+					size="icon-sm"
+					variant="ghost"
+					onclick={closeSettings}
+					aria-label="Close settings"
+				>
+					<X />
+				</Button>
+			</div>
+
+			<div class="min-h-0 grow overflow-y-auto px-4 pt-2 pb-10">
+				{#each results as category (category.label)}
+					<Tabs.Content class="mx-auto max-w-xl" value={category.label}>
+						<Category {category} query={searching ? query.trim() : ""} />
+					</Tabs.Content>
+				{/each}
+			</div>
+		</div>
+	</Tabs.Root>
+</Dialog>
+
+<style>
+	:global(#settings-tabs [data-slot="separator"]) {
+		margin: calc(var(--spacing) * 1) 0;
+	}
+</style>

--- a/src/lib/components/settings/SidebarActions.svelte
+++ b/src/lib/components/settings/SidebarActions.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+	import { invoke } from "@tauri-apps/api/core";
+	import { appLogDir } from "@tauri-apps/api/path";
+	import { writeText } from "@tauri-apps/plugin-clipboard-manager";
+	import { openPath } from "@tauri-apps/plugin-opener";
+	import { scale } from "svelte/transition";
+	import Button from "$lib/components/ui/Button.svelte";
+	import { logOut } from "$lib/twitch/auth";
+	import Check from "~icons/ph/check";
+	import Clipboard from "~icons/ph/clipboard";
+	import FolderOpen from "~icons/ph/folder-open";
+	import SignOut from "~icons/ph/sign-out";
+
+	let copied = $state(false);
+
+	async function openLogDir() {
+		await openPath(await appLogDir());
+	}
+
+	async function copyDebugInfo() {
+		const info = await invoke<string>("get_debug_info");
+
+		// Need to use clipboard plugin because of timing sensitivity with the
+		// Clipboard API
+		await writeText(info);
+		copied = true;
+
+		setTimeout(() => {
+			copied = false;
+		}, 2000);
+	}
+</script>
+
+<div class="space-y-0.5 *:w-full *:justify-start">
+	<Button class="text-muted-foreground" variant="ghost" onclick={openLogDir}>
+		<FolderOpen />
+		<span class="text-sm">Open logs</span>
+	</Button>
+
+	<Button class="px-4 text-muted-foreground" variant="ghost" onclick={copyDebugInfo}>
+		{#if copied}
+			<span in:scale={{ duration: 300, start: 0.85 }}>
+				<Check />
+			</span>
+		{:else}
+			<span in:scale={{ duration: 300, start: 0.85 }}>
+				<Clipboard />
+			</span>
+		{/if}
+
+		<span class="text-sm">Copy debug info</span>
+	</Button>
+
+	<Button class="text-muted-foreground" variant="ghost" onclick={logOut}>
+		<SignOut />
+		<span class="text-sm">Log out</span>
+	</Button>
+</div>

--- a/src/lib/components/settings/categories/advanced.ts
+++ b/src/lib/components/settings/categories/advanced.ts
@@ -1,0 +1,45 @@
+import Toolbox from "~icons/ph/toolbox";
+import ClearCache from "../custom/ClearCache.svelte";
+import type { SettingsCategory } from "../types";
+
+export default {
+	order: 9999,
+	label: "Advanced",
+	icon: Toolbox,
+	fields: [
+		{
+			type: "group",
+			label: "Logs",
+			fields: [
+				{
+					id: "advanced.logs.level",
+					type: "select",
+					label: "Level",
+					description:
+						"Set the verbosity of application logs. Higher levels provide more detailed information for debugging but may quickly grow in size.",
+					items: [
+						{ label: "Error", value: "error" },
+						{ label: "Warn", value: "warn" },
+						{ label: "Info", value: "info" },
+						{ label: "Debug", value: "debug" },
+						{ label: "Trace", value: "trace" },
+					],
+				},
+			],
+		},
+		{
+			type: "group",
+			label: "Cache",
+			fields: [
+				{
+					id: "advanced.cache.clear",
+					type: "custom",
+					label: "Clear",
+					description: "Clear the application cache to free up space or resolve issues.",
+					renderAs: "field",
+					component: ClearCache,
+				},
+			],
+		},
+	],
+} satisfies SettingsCategory;

--- a/src/lib/components/settings/categories/appearance.ts
+++ b/src/lib/components/settings/categories/appearance.ts
@@ -1,0 +1,26 @@
+import Monitor from "~icons/ph/palette";
+import Custom from "../custom/theme/Custom.svelte";
+import Default from "../custom/theme/Default.svelte";
+import type { SettingsCategory } from "../types";
+
+export default {
+	order: 10,
+	label: "Appearance",
+	icon: Monitor,
+	fields: [
+		{
+			id: "appearance.default",
+			type: "custom",
+			label: "Default theme",
+			component: Default,
+		},
+		{
+			id: "appearance.theme",
+			type: "custom",
+			label: "Custom theme",
+			description:
+				"Completely customize the appearance of the application with CSS. Make your own or download themes created by the community.",
+			component: Custom,
+		},
+	],
+} satisfies SettingsCategory;

--- a/src/lib/components/settings/categories/chat.ts
+++ b/src/lib/components/settings/categories/chat.ts
@@ -1,0 +1,220 @@
+import { settings } from "$lib/settings";
+import Chat from "~icons/ph/chat";
+import type { SettingsCategory } from "../types";
+
+export default {
+	order: 20,
+	label: "Chat",
+	icon: Chat,
+	fields: [
+		{
+			type: "group",
+			fields: [
+				{
+					id: "chat.hideScrollbar",
+					type: "switch",
+					label: "Hide scrollbar",
+					description: "Toggle the visibility of the scrollbar.",
+				},
+				{
+					id: "chat.newSeparator",
+					type: "switch",
+					label: "New messages separator",
+					description: "Show a separator for new messages when the window loses focus.",
+				},
+				{
+					id: "chat.embeds",
+					type: "switch",
+					label: "Enable embeds",
+					description: "Show embedded content for supported links.",
+				},
+			],
+		},
+		{
+			type: "group",
+			label: "Badges",
+			fields: [
+				{
+					id: "chat.badges.ffz",
+					type: "switch",
+					label: "Enable FrankerFaceZ badges",
+					description:
+						'Show badges from <a href="https://www.frankerfacez.com/" target="_blank">FrankerFaceZ</a>.',
+				},
+				{
+					id: "chat.badges.bttv",
+					type: "switch",
+					label: "Enable BetterTTV badges",
+					description:
+						'Show badges from <a href="https://betterttv.com/" target="_blank">BetterTTV</a>.',
+				},
+				{
+					id: "chat.badges.seventv",
+					type: "switch",
+					label: "Enable 7TV badges",
+					description:
+						'Show badges from <a href="https://7tv.app/" target="_blank">7TV</a>.',
+				},
+			],
+		},
+		{
+			type: "group",
+			label: "Usernames",
+			fields: [
+				{
+					id: "chat.usernames.localized",
+					type: "switch",
+					label: "Display localized names",
+					description:
+						"Show the user's localized display name if they have their Twitch language set to Arabic, Chinese, Japanese, or Korean.",
+				},
+				{
+					id: "chat.usernames.readable",
+					type: "switch",
+					label: "Readable name colors",
+					description:
+						"Lightens or darkens the color of usernames based on the current theme. This does not apply to 7TV paints.",
+				},
+				{
+					id: "chat.usernames.randomColor",
+					type: "switch",
+					label: "Assign random colors",
+					description:
+						"Assign a random Twitch color to usernames that do not have a color set.",
+				},
+				{
+					id: "chat.usernames.paint",
+					type: "switch",
+					label: "Paint usernames",
+					description: "Style usernames with 7TV paints if the user has one.",
+				},
+				{
+					id: "chat.usernames.mentionStyle",
+					type: "radio",
+					label: "Mention style",
+					description:
+						"Choose how mentions in messages are displayed. Painted mentions will fallback to the user's color if they have no 7TV paint.",
+					items: [
+						{ label: "None", value: "none" },
+						{ label: "Colored", value: "colored" },
+						{ label: "Painted", value: "painted" },
+					],
+				},
+			],
+		},
+		{
+			type: "group",
+			label: "Emotes",
+			fields: [
+				{
+					id: "chat.emotes.ffz",
+					type: "switch",
+					label: "Enable FrankerFaceZ emotes",
+					description:
+						'Show and autocomplete emotes from <a href="https://www.frankerfacez.com/" target="_blank">FrankerFaceZ</a>.',
+				},
+				{
+					id: "chat.emotes.bttv",
+					type: "switch",
+					label: "Enable BetterTTV emotes",
+					description:
+						'Show and autocomplete emotes from <a href="https://betterttv.com/" target="_blank">BetterTTV</a>.',
+				},
+				{
+					id: "chat.emotes.seventv",
+					type: "switch",
+					label: "Enable 7TV emotes",
+					description:
+						'Show and autocomplete emotes from <a href="https://7tv.app/" target="_blank">7TV</a>.',
+				},
+				{
+					id: "chat.emotes.padding",
+					type: "slider",
+					label: "Padding",
+					description: "Adjust the spacing around emotes in chat.",
+					formatValue: (value) => `${value}px`,
+					showSteps: true,
+					min: 0,
+					max: 10,
+					step: 1,
+				},
+			],
+		},
+		{
+			type: "group",
+			label: "Messages",
+			fields: [
+				{
+					id: "chat.messages.duplicateBypass",
+					type: "switch",
+					label: "Bypass duplicate message warning",
+					description:
+						"Allows you to send identical messages even if you're not a moderator or a VIP.",
+				},
+				{
+					type: "group",
+					label: "History",
+					fields: [
+						{
+							id: "chat.messages.history.enabled",
+							type: "switch",
+							label: "Fetch recent messages upon joining a channel",
+							description:
+								'This feature uses a <a href="https://recent-messages.robotty.de/" target="_blank">third-party API</a> that temporarily stores the messages sent in joined channels. To opt-out, disable this setting.',
+						},
+						{
+							id: "chat.messages.history.limit",
+							type: "slider",
+							label: "Limit",
+							description:
+								"Change how many previous messages to load when joining a channel.",
+							min: 0,
+							max: 800,
+							step: 50,
+							disabled: () => !settings.state["chat.messages.history.enabled"],
+						},
+						{
+							id: "chat.messages.history.separator",
+							type: "switch",
+							label: "Separate recent messages",
+							description: "Show a separator between recent and live messages.",
+						},
+					],
+				},
+				{
+					type: "group",
+					label: "Timestamps",
+					fields: [
+						{
+							id: "chat.messages.timestamps.show",
+							type: "switch",
+							label: "Show timestamps next to messages",
+						},
+						{
+							id: "chat.messages.timestamps.format",
+							type: "radio",
+							label: "Format",
+							items: [
+								{ label: "Auto", value: "auto" },
+								{ label: "12-hour", value: "12" },
+								{ label: "24-hour", value: "24" },
+								{ label: "Custom", value: "custom" },
+							],
+							disabled: () => !settings.state["chat.messages.timestamps.show"],
+						},
+						{
+							id: "chat.messages.timestamps.customFormat",
+							type: "input",
+							label: "Custom format",
+							description:
+								'Formats use the same <a href="https://day.js.org/docs/en/display/format" target="_blank">tokens</a> as <a href="https://day.js.org/en" target="_blank">Day.js</a>. Localized formats are also enabled.',
+							placeholder: "e.g. HH:mm:ss",
+							disabled: () =>
+								settings.state["chat.messages.timestamps.format"] !== "custom",
+						},
+					],
+				},
+			],
+		},
+	],
+} satisfies SettingsCategory;

--- a/src/lib/components/settings/categories/highlights.ts
+++ b/src/lib/components/settings/categories/highlights.ts
@@ -1,0 +1,36 @@
+import Highlighter from "~icons/ph/highlighter";
+import Keyword from "../custom/highlights/Keyword.svelte";
+import Viewer from "../custom/highlights/Viewer.svelte";
+import type { SettingsCategory } from "../types";
+
+export default {
+	order: 30,
+	label: "Highlights",
+	icon: Highlighter,
+	fields: [
+		{
+			id: "highlights.enabled",
+			type: "switch",
+			label: "Highlight messages",
+			description:
+				"Message highlights allow you to easily identify different types of viewers or when specific keywords are sent in chat.",
+		},
+		{
+			id: "highlights.viewers",
+			type: "custom",
+			label: "Viewers",
+			description:
+				"Switch individual highlights on or off to focus on the types of viewers you want to recognize.",
+			component: Viewer,
+		},
+		{
+			id: "highlights.keywords",
+			type: "custom",
+			label: "Keywords",
+			// TODO: temporary description, link to docs when site is up
+			description:
+				"Keyword highlights can use regular expressions, be matched as whole words, and be case sensitive.",
+			component: Keyword,
+		},
+	],
+} satisfies SettingsCategory;

--- a/src/lib/components/settings/categories/splits.ts
+++ b/src/lib/components/settings/categories/splits.ts
@@ -1,0 +1,16 @@
+import Layout from "~icons/ph/layout";
+import type { SettingsCategory } from "../types";
+
+export default {
+	order: 15,
+	label: "Splits",
+	icon: Layout,
+	fields: [
+		{
+			id: "splits.leaveOnClose",
+			type: "switch",
+			label: "Leave channel on close",
+			description: "Automatically leave a channel when closing its tab.",
+		},
+	],
+} satisfies SettingsCategory;

--- a/src/lib/components/settings/custom/ClearCache.svelte
+++ b/src/lib/components/settings/custom/ClearCache.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import { invoke } from "@tauri-apps/api/core";
+	import { onMount } from "svelte";
+	import { clear } from "tauri-plugin-cache-api";
+	import Button from "$lib/components/ui/Button.svelte";
+	import Broom from "~icons/ph/broom";
+
+	let bytes = $state(0);
+
+	const size = $derived.by(() => {
+		if (bytes >= 1024 * 1024) {
+			return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+		}
+
+		if (bytes >= 1024) {
+			return `${Math.round(bytes / 1024)} KB`;
+		}
+
+		return `${bytes} bytes`;
+	});
+
+	onMount(async () => {
+		bytes = await invoke<number>("get_cache_size");
+	});
+</script>
+
+<Button
+	class="max-w-min"
+	size="sm"
+	disabled={!bytes}
+	onclick={async () => {
+		await clear();
+		bytes = await invoke<number>("get_cache_size");
+	}}
+>
+	<Broom /> Free up {size}
+</Button>

--- a/src/lib/components/settings/custom/highlights/Color.svelte
+++ b/src/lib/components/settings/custom/highlights/Color.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import ColorPicker from "$lib/components/ui/ColorPicker.svelte";
+	import Popover from "$lib/components/ui/Popover.svelte";
+
+	interface Props {
+		id: string;
+		value: string;
+	}
+
+	let { id, value = $bindable() }: Props = $props();
+</script>
+
+<button
+	class="size-8 shrink-0 cursor-pointer rounded-lg border border-black/15 bg-(--highlight) shadow-xs ring-offset-background transition-[filter,scale,box-shadow] outline-none hover:scale-105 focus-visible:ring-[3px] focus-visible:ring-ring/50 dark:border-white/20"
+	popovertarget="color-picker-{id}"
+	title="Change color"
+	aria-label="Toggle color picker"
+	style:--highlight={value}
+></button>
+
+<Popover id="color-picker-{id}" class="w-60">
+	<ColorPicker bind:value />
+</Popover>

--- a/src/lib/components/settings/custom/highlights/Edit.svelte
+++ b/src/lib/components/settings/custom/highlights/Edit.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+	import Button from "$lib/components/ui/Button.svelte";
+	import Checkbox from "$lib/components/ui/Checkbox.svelte";
+	import Dialog from "$lib/components/ui/Dialog.svelte";
+	import * as Field from "$lib/components/ui/field";
+	import Input from "$lib/components/ui/Input.svelte";
+	import type { KeywordHighlightConfig } from "$lib/settings";
+	import Pencil from "~icons/ph/pencil";
+
+	let { config = $bindable<KeywordHighlightConfig>() } = $props();
+
+	const id = $props.id();
+
+	const dialogId = `edit-highlight-dialog-${id}`;
+</script>
+
+<Button
+	class="text-muted-foreground hover:text-foreground"
+	title="Edit"
+	command="show-modal"
+	commandfor={dialogId}
+	size="icon-sm"
+	variant="ghost"
+	aria-label="Edit pattern"
+>
+	<Pencil />
+</Button>
+
+<Dialog id={dialogId}>
+	{#snippet header()}
+		<h2>Edit pattern</h2>
+	{/snippet}
+
+	<Field.Field>
+		<Field.Label for="p-{id}">Pattern</Field.Label>
+
+		<Input
+			id="p-{id}"
+			autocapitalize="off"
+			autocorrect="off"
+			placeholder="Enter pattern"
+			bind:value={config.pattern}
+		/>
+	</Field.Field>
+
+	<Field.Group class="gap-3">
+		<Field.Field orientation="horizontal">
+			<Checkbox id="r-{id}" bind:checked={config.regex} />
+
+			<Field.Label class="font-normal" for="r-{id}">Match as regular expression</Field.Label>
+		</Field.Field>
+
+		<Field.Field orientation="horizontal">
+			<Checkbox id="w-{id}" bind:checked={config.wholeWord} />
+
+			<Field.Label class="font-normal" for="w-{id}">Match whole word</Field.Label>
+		</Field.Field>
+
+		<Field.Field orientation="horizontal">
+			<Checkbox id="c-{id}" bind:checked={config.matchCase} />
+
+			<Field.Label class="font-normal" for="c-{id}">Match case</Field.Label>
+		</Field.Field>
+	</Field.Group>
+
+	{#snippet footer()}
+		<Button command="close" commandfor={dialogId}>Save</Button>
+	{/snippet}
+</Dialog>

--- a/src/lib/components/settings/custom/highlights/Keyword.svelte
+++ b/src/lib/components/settings/custom/highlights/Keyword.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+	import Button from "$lib/components/ui/Button.svelte";
+	import * as Empty from "$lib/components/ui/empty";
+	import { settings } from "$lib/settings";
+	import type { KeywordHighlightConfig } from "$lib/settings";
+	import CaseSensitive from "~icons/local/case-sensitive";
+	import Regex from "~icons/local/regex";
+	import WholeWord from "~icons/local/whole-word";
+	import Highlighter from "~icons/ph/highlighter";
+	import Plus from "~icons/ph/plus";
+	import Trash from "~icons/ph/trash";
+	import Edit from "./Edit.svelte";
+	import Row from "./Row.svelte";
+
+	const keywords = $derived(settings.state["highlights.keywords"]);
+
+	function add() {
+		keywords.push({
+			enabled: true,
+			pattern: "",
+			style: "default",
+			color: "#ff0000",
+			regex: false,
+			wholeWord: false,
+			matchCase: false,
+		} satisfies KeywordHighlightConfig);
+	}
+</script>
+
+<div class="flex flex-col gap-2">
+	{#if keywords.length === 0}
+		<Empty.Root class="border border-dashed py-8">
+			<Empty.Header>
+				<Empty.Media variant="icon">
+					<Highlighter />
+				</Empty.Media>
+
+				<Empty.Title>No keyword triggers</Empty.Title>
+
+				<Empty.Description>
+					Add a trigger to highlight messages containing specific words.
+				</Empty.Description>
+			</Empty.Header>
+		</Empty.Root>
+	{/if}
+
+	{#each keywords as config, i}
+		<Row
+			type="custom"
+			id="keyword-{i}"
+			label={config.pattern || "Empty pattern"}
+			bind:config={keywords[i]}
+		>
+			{#snippet badges()}
+				<div class="flex shrink-0 items-center gap-1.5 text-muted-foreground">
+					{#if config.matchCase}
+						<span title="Match case"><CaseSensitive class="size-4" /></span>
+					{/if}
+
+					{#if config.wholeWord}
+						<span title="Match whole word"><WholeWord class="size-4" /></span>
+					{/if}
+
+					{#if config.regex}
+						<span title="Regular expression"><Regex class="size-4" /></span>
+					{/if}
+				</div>
+			{/snippet}
+
+			{#snippet actions()}
+				<Edit bind:config={keywords[i]} />
+
+				<Button
+					class="text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+					title="Delete"
+					size="icon-sm"
+					variant="ghost"
+					aria-label="Delete trigger"
+					onclick={() => keywords.splice(i, 1)}
+				>
+					<Trash />
+				</Button>
+			{/snippet}
+		</Row>
+	{/each}
+
+	<Button class="self-start" variant="outline" onclick={add}>
+		<Plus />
+		Add new trigger
+	</Button>
+</div>

--- a/src/lib/components/settings/custom/highlights/Row.svelte
+++ b/src/lib/components/settings/custom/highlights/Row.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+	import type { Snippet } from "svelte";
+	import { decorations } from "$lib/components/message/Highlight.svelte";
+	import type { HighlightConfig } from "$lib/settings";
+	import Color from "./Color.svelte";
+	import StyleSelect from "./Style.svelte";
+
+	interface Props {
+		type: keyof typeof decorations;
+		id: string;
+		label?: string;
+		config: HighlightConfig;
+		actions?: Snippet;
+		badges?: Snippet;
+	}
+
+	let { type, id, label, config = $bindable(), actions, badges }: Props = $props();
+
+	const decoration = $derived(decorations[type]);
+	const title = $derived(label || decoration.label);
+</script>
+
+<div class="@container">
+	<div
+		class="group flex flex-wrap items-center gap-2 rounded-xl border bg-background/50 px-3 py-2.5 transition-[border-color] duration-200"
+		data-enabled={config.enabled}
+		style:border-color={config.enabled ? config.color : undefined}
+	>
+		<div
+			class="flex min-w-0 flex-1 items-center gap-2.5 transition-opacity duration-200 group-data-[enabled=false]:opacity-45"
+		>
+			<span
+				class="shrink-0 group-data-[enabled=false]:text-muted-foreground"
+				style:color={config.enabled ? config.color : undefined}
+			>
+				<decoration.icon class="size-4" />
+			</span>
+
+			<span
+				class="truncate text-sm font-medium group-data-[enabled=false]:text-muted-foreground"
+				{title}
+			>
+				{title}
+			</span>
+
+			{@render badges?.()}
+		</div>
+
+		<div
+			class="flex shrink-0 items-center gap-2 @max-[350px]:order-last @max-[350px]:w-full @max-[350px]:**:data-[slot=native-select-wrapper]:flex-1"
+		>
+			<Color {id} bind:value={config.color} />
+			<StyleSelect bind:config />
+		</div>
+
+		{#if actions}
+			<div
+				class="flex shrink-0 items-center gap-0.5 transition-opacity duration-200 group-data-[enabled=false]:opacity-45"
+			>
+				{@render actions()}
+			</div>
+		{/if}
+	</div>
+</div>

--- a/src/lib/components/settings/custom/highlights/Style.svelte
+++ b/src/lib/components/settings/custom/highlights/Style.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	import { cn } from "tailwind-variants";
+	import * as NativeSelect from "$lib/components/ui/native-select";
+	import type { HighlightConfig } from "$lib/settings";
+
+	const styles = [
+		{ label: "Default", value: "default" },
+		{ label: "Compact", value: "compact" },
+		{ label: "Background", value: "background" },
+		{ label: "Disabled", value: "disabled" },
+	];
+
+	let { config = $bindable<HighlightConfig>(), class: className = undefined } = $props();
+</script>
+
+<NativeSelect.Root
+	class={cn("min-w-32", className)}
+	aria-label="Highlight style"
+	bind:value={
+		() => (config.enabled ? config.style : "disabled"),
+		(value) => {
+			if (value === "disabled") {
+				config.enabled = false;
+			} else {
+				config.enabled = true;
+				config.style = value;
+			}
+		}
+	}
+>
+	{#each styles as style}
+		<NativeSelect.Option value={style.value}>
+			{style.label}
+		</NativeSelect.Option>
+	{/each}
+</NativeSelect.Root>

--- a/src/lib/components/settings/custom/highlights/Viewer.svelte
+++ b/src/lib/components/settings/custom/highlights/Viewer.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+	import Button from "$lib/components/ui/Button.svelte";
+	import { defaultHighlightTypes, settings } from "$lib/settings";
+	import type { HighlightType } from "$lib/settings";
+	import ArrowClockwise from "~icons/ph/arrow-clockwise";
+	import Row from "./Row.svelte";
+
+	const highlights = [
+		{ label: "Mentions", value: "mention" },
+		{ label: "First Time Chats", value: "new" },
+		{ label: "Returning Chatters", value: "returning" },
+		{ label: "Suspicious Users", value: "suspicious" },
+		{ label: "Broadcasters", value: "broadcaster" },
+		{ label: "Moderators", value: "moderator" },
+		{ label: "Subscribers", value: "subscriber" },
+		{ label: "VIPs", value: "vip" },
+	] as const;
+
+	const viewers = $derived(settings.state["highlights.viewers"]);
+
+	function reset(key: HighlightType) {
+		viewers[key] = { ...defaultHighlightTypes[key] };
+	}
+
+	function isDefault(key: HighlightType) {
+		const config = viewers[key];
+		const original = defaultHighlightTypes[key];
+
+		return (
+			config.enabled === original.enabled &&
+			config.color === original.color &&
+			config.style === original.style
+		);
+	}
+</script>
+
+<div class="flex flex-col gap-2">
+	{#each highlights as highlight (highlight.value)}
+		<Row
+			type={highlight.value}
+			id={highlight.value}
+			label={highlight.label}
+			bind:config={viewers[highlight.value]}
+		>
+			{#snippet actions()}
+				<Button
+					class="text-muted-foreground hover:text-foreground"
+					title="Reset to default"
+					size="icon-sm"
+					variant="ghost"
+					aria-label="Reset {highlight.label} to default"
+					disabled={isDefault(highlight.value)}
+					onclick={() => reset(highlight.value)}
+				>
+					<ArrowClockwise />
+				</Button>
+			{/snippet}
+		</Row>
+	{/each}
+</div>

--- a/src/lib/components/settings/custom/theme/Custom.svelte
+++ b/src/lib/components/settings/custom/theme/Custom.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+	import { openPath } from "@tauri-apps/plugin-opener";
+	import { app } from "$lib/app.svelte";
+	import Button from "$lib/components/ui/Button.svelte";
+	import * as Field from "$lib/components/ui/field";
+	import * as RadioGroup from "$lib/components/ui/radio-group";
+	import Separator from "$lib/components/ui/Separator.svelte";
+	import { settings } from "$lib/settings";
+	import { getThemesDir, injectTheme, loadThemes } from "$lib/themes";
+
+	$effect(() => {
+		injectTheme(settings.state["appearance.theme"]);
+	});
+
+	async function openThemeDir() {
+		await openPath(await getThemesDir());
+	}
+</script>
+
+<div class="flex items-center gap-x-2">
+	<Button size="sm" onclick={openThemeDir}>Open folder</Button>
+
+	<Button
+		size="sm"
+		variant="outline"
+		disabled={!app.themes.size}
+		onclick={() => (settings.state["appearance.theme"] = "")}
+	>
+		Clear selection
+	</Button>
+
+	<Button size="sm" variant="outline" onclick={() => loadThemes()}>Reload themes</Button>
+</div>
+
+<RadioGroup.Root bind:value={settings.state["appearance.theme"]}>
+	{#each app.themes as [id, theme] (id)}
+		<Field.Label for={id}>
+			<Field.Field orientation="horizontal">
+				<Field.Content>
+					<Field.Title>{theme.name}</Field.Title>
+
+					<Field.Description>
+						{theme.description}
+					</Field.Description>
+
+					<div class="flex h-5 items-center gap-x-2 text-xs text-muted-foreground">
+						{theme.author}
+
+						{#if theme.repository}
+							<Separator orientation="vertical" />
+							<a href={theme.repository} target="_blank">Repository</a>
+						{/if}
+
+						<Separator orientation="vertical" />
+
+						v{theme.version}
+					</div>
+				</Field.Content>
+
+				<RadioGroup.Item {id} value={id} />
+			</Field.Field>
+		</Field.Label>
+	{/each}
+</RadioGroup.Root>

--- a/src/lib/components/settings/custom/theme/Default.svelte
+++ b/src/lib/components/settings/custom/theme/Default.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+	import { RadioGroup } from "bits-ui";
+	import { setMode, userPrefersMode } from "mode-watcher";
+
+	const themes = [
+		{ value: "light", label: "Light" },
+		{ value: "dark", label: "Dark" },
+		{ value: "system", label: "System" },
+	] as const;
+</script>
+
+<div class="@container">
+	<RadioGroup.Root
+		class="grid gap-3 @max-md:max-w-3xs @min-md:grid-cols-3"
+		bind:value={() => userPrefersMode.current, (value) => setMode(value)}
+	>
+		{#each themes as theme (theme.value)}
+			<RadioGroup.Item
+				class="cursor-pointer overflow-hidden rounded-xl border text-left transition-[border-color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 data-[state=checked]:ring-1 data-[state=checked]:ring-primary"
+				value={theme.value}
+			>
+				{#snippet children({ checked })}
+					<div class="aspect-4/3 w-full border-b">
+						{#if theme.value === "system"}
+							<div class="relative size-full">
+								<div class="absolute inset-0 [clip-path:inset(0_50%_0_0)]">
+									{@render shell(false)}
+								</div>
+
+								<div class="absolute inset-0 [clip-path:inset(0_0_0_50%)]">
+									{@render shell(true)}
+								</div>
+							</div>
+						{:else}
+							{@render shell(theme.value === "dark")}
+						{/if}
+					</div>
+
+					<div class="flex items-center gap-2 px-3 py-2.5">
+						<span
+							class={[
+								"flex size-4 shrink-0 items-center justify-center rounded-full border border-input shadow-xs",
+								checked && "border-primary",
+							]}
+						>
+							{#if checked}
+								<span class="size-2 rounded-full bg-primary"></span>
+							{/if}
+						</span>
+
+						<span class="text-sm font-medium">{theme.label}</span>
+					</div>
+				{/snippet}
+			</RadioGroup.Item>
+		{/each}
+	</RadioGroup.Root>
+</div>
+
+{#snippet shell(dark: boolean)}
+	{@const surface = dark ? "bg-neutral-950" : "bg-white"}
+	{@const chrome = dark ? "bg-neutral-900" : "bg-neutral-100"}
+	{@const bar = dark ? "bg-neutral-700" : "bg-neutral-300"}
+	{@const dot = dark ? "bg-neutral-800" : "bg-neutral-200"}
+
+	<div class="flex size-full flex-col {surface}">
+		<div class="flex shrink-0 items-center gap-1 px-1.5 py-1.5 {chrome}">
+			<div class="h-1 w-4 rounded-full {bar}"></div>
+			<div class="h-1 w-3 rounded-full {bar}"></div>
+			<div class="ml-auto h-1 w-1 rounded-full {bar}"></div>
+		</div>
+
+		<div class="flex min-h-0 flex-1">
+			<div class="flex shrink-0 flex-col items-center gap-1 px-1 py-1.5 {chrome}">
+				<div class="size-2 rounded-full {bar}"></div>
+				<div class="size-2 rounded-full {dot}"></div>
+				<div class="size-2 rounded-full {dot}"></div>
+			</div>
+
+			<div class="flex min-w-0 flex-1 flex-col gap-1 p-1.5">
+				<div class="h-1 w-10/12 rounded-full {bar}"></div>
+				<div class="h-1 w-7/12 rounded-full {dot}"></div>
+				<div class="h-1 w-9/12 rounded-full {dot}"></div>
+				<div class="h-1 w-6/12 rounded-full {bar}"></div>
+				<div class="h-1 w-8/12 rounded-full {dot}"></div>
+
+				<div class="mt-auto h-2.5 w-full rounded-sm {chrome}"></div>
+			</div>
+		</div>
+	</div>
+{/snippet}

--- a/src/lib/components/settings/search.ts
+++ b/src/lib/components/settings/search.ts
@@ -1,0 +1,79 @@
+import type { SettingsCategory, SettingsField } from "./types";
+
+function fieldText(field: SettingsField): string {
+	const parts = [field.label ?? ""];
+
+	if (field.type !== "group") {
+		parts.push(field.id.replaceAll(".", " "));
+
+		if (field.description) {
+			// Descriptions may contain markup, which shouldn't match
+			parts.push(field.description.replaceAll(/<[^>]*>/g, " "));
+		}
+
+		if (field.keywords) {
+			parts.push(...field.keywords);
+		}
+
+		if (field.type === "radio" || field.type === "select") {
+			for (const item of field.items) {
+				parts.push(item.label, item.description ?? "");
+			}
+		}
+	}
+
+	return parts.join(" ").toLowerCase();
+}
+
+function matches(text: string, tokens: string[]): boolean {
+	return tokens.every((token) => text.includes(token));
+}
+
+function filterFields(fields: SettingsField[], tokens: string[], context: string) {
+	const result: SettingsField[] = [];
+
+	for (const field of fields) {
+		// Ancestor labels count towards a match, so "chat timestamps" works
+		const text = `${context} ${fieldText(field)}`;
+
+		if (field.type === "group") {
+			if (matches(text, tokens)) {
+				result.push(field);
+				continue;
+			}
+
+			const nested = filterFields(field.fields, tokens, text);
+
+			if (nested.length > 0) {
+				result.push({ ...field, fields: nested });
+			}
+		} else if (matches(text, tokens)) {
+			result.push(field);
+		}
+	}
+
+	return result;
+}
+
+export function filterCategory(category: SettingsCategory, query: string): SettingsCategory {
+	const tokens = query.toLowerCase().split(/\s+/).filter(Boolean);
+
+	if (tokens.length === 0) {
+		return category;
+	}
+
+	return {
+		...category,
+		fields: filterFields(category.fields, tokens, category.label.toLowerCase()),
+	};
+}
+
+export function countFields(fields: SettingsField[]): number {
+	let count = 0;
+
+	for (const field of fields) {
+		count += field.type === "group" ? countFields(field.fields) : 1;
+	}
+
+	return count;
+}

--- a/src/lib/components/settings/types.ts
+++ b/src/lib/components/settings/types.ts
@@ -1,0 +1,97 @@
+import type { Component } from "svelte";
+import type { Settings } from "$lib/settings";
+
+type SettingKey = keyof Settings;
+
+/**
+ * Keys of {@linkcode Settings} whose value is assignable to `T`.
+ */
+type KeysWithValue<T> = {
+	[K in SettingKey]: Settings[K] extends T ? K : never;
+}[SettingKey];
+
+/**
+ * Keys of {@linkcode Settings} whose value is exactly `T`.
+ */
+type KeysWithExactValue<T> = {
+	[K in SettingKey]: [Settings[K]] extends [T] ? ([T] extends [Settings[K]] ? K : never) : never;
+}[SettingKey];
+
+export interface BaseField<Id extends string = string> {
+	id: Id;
+	label: string;
+	description?: string;
+	keywords?: string[];
+	disabled?: () => boolean;
+}
+
+interface GroupField {
+	type: "group";
+	label?: string;
+	fields: SettingsField[];
+}
+
+interface CustomField extends BaseField {
+	type: "custom";
+	renderAs?: "field" | "set";
+	component: Component;
+}
+
+interface InputField extends BaseField<KeysWithExactValue<string>> {
+	type: "input";
+	placeholder?: string;
+}
+
+interface ChoiceItem<Value extends string> {
+	label: string;
+	value: Value;
+	description?: string;
+}
+
+interface RadioFieldFor<K extends KeysWithValue<string>> extends BaseField<K> {
+	type: "radio";
+	items: ChoiceItem<Settings[K] & string>[];
+}
+
+interface SelectFieldFor<K extends KeysWithValue<string>> extends BaseField<K> {
+	type: "select";
+	items: ChoiceItem<Settings[K] & string>[];
+}
+
+type RadioField = {
+	[K in KeysWithValue<string>]: RadioFieldFor<K>;
+}[KeysWithValue<string>];
+
+type SelectField = {
+	[K in KeysWithValue<string>]: SelectFieldFor<K>;
+}[KeysWithValue<string>];
+
+interface SliderField extends BaseField<KeysWithValue<number>> {
+	type: "slider";
+	formatValue?: (value: number) => string;
+	showSteps?: boolean;
+	min?: number;
+	max?: number;
+	step?: number | number[];
+}
+
+interface SwitchField extends BaseField<KeysWithValue<boolean>> {
+	type: "switch";
+	onchange?: (value: boolean) => void;
+}
+
+export type SettingsField =
+	| GroupField
+	| CustomField
+	| InputField
+	| RadioField
+	| SelectField
+	| SliderField
+	| SwitchField;
+
+export interface SettingsCategory {
+	order: number;
+	label: string;
+	icon: Component;
+	fields: SettingsField[];
+}


### PR DESCRIPTION
Adds `components/settings/` -- the settings surface rebuilt on the new
Dialog primitive, with category search and field definitions typed against
the settings schema.

Additive: the `/settings` route is untouched and still the live entry
point. The title bar switches over in the next PR, which is also where the
old route is removed.

Supersedes the in-branch work from #235 and #236.



---

### The stack

Merge bottom-up. Each PR is based on the one above it, and each one
type-checks on its own (`vp run check`, 0 errors).

| # | PR | What |
|---|----|------|
| 1 | #240 | `cn` from tailwind-variants, shadow-plugin, css tokens |
| 2 | #241 | Button restyle + Link |
| 3 | #242 | Slider rebuild |
| 4 | #243 | Dialog / Popover / Tooltip |
| 5 | #244 | Input, Textarea, Checkbox, Switch, Progress, Separator, Label, ColorPicker |
| 6 | #245 | Message components |
| 7 | #246 | `components/stream/` + number-flow |
| 8 | #247 | Kept shadcn wrappers polish |
| 9 | #248 | Settings as a dialog |
| 10 | #249 | Chat, channel views, app shell, data layer |
| 11 | #250 | Drop the orphaned shadcn barrels |

Replaces #207, which was 179 files in one review.

The stack tip is byte-identical to `feat/ui-overhaul-v2` — verified with
`git diff ui/11-cleanup feat/ui-overhaul-v2` (empty).

PRs 2–9 are deliberately **additive**: they add the new component next to
the old one without migrating call sites, so each can be read on its own.
The migrations happen in #249, and #250 deletes what is then unreferenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
