### PR TITLE
feat: move auth to webview

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,6 @@ importers:
   .:
     configDependencies: {}
     packageManagerDependencies:
-      '@pnpm/exe':
-        specifier: 12.0.0
-        version: 12.0.0
       pnpm:
         specifier: 12.0.0
         version: 12.0.0
@@ -59,11 +56,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@pnpm/exe@12.0.0':
-    resolution: {integrity: sha512-405vw2qYPPghNxoPRt2cvkGtGNU5gnInDcIe5TztQxe73yUZLqFJN/jCJFGs1xbVaIWDXEVuQ71P8npFZeatZQ==}
-    engines: {node: '>=18.*'}
-    hasBin: true
-
   pnpm@12.0.0:
     resolution: {integrity: sha512-ni49w5EZlYaNyUuBdcIXwn6VQI+gO0oidJd48rNPdzt3zdOznt6BcbIvzVO+ajU0Lp+smUimjvWN9kiM6Jp+Zw==}
     engines: {node: '>=18.*'}
@@ -94,17 +86,6 @@ snapshots:
 
   '@pnpm/exe.win32-x64@12.0.0':
     optional: true
-
-  '@pnpm/exe@12.0.0':
-    optionalDependencies:
-      '@pnpm/exe.darwin-arm64': 12.0.0
-      '@pnpm/exe.darwin-x64': 12.0.0
-      '@pnpm/exe.linux-arm64': 12.0.0
-      '@pnpm/exe.linux-arm64-musl': 12.0.0
-      '@pnpm/exe.linux-x64': 12.0.0
-      '@pnpm/exe.linux-x64-musl': 12.0.0
-      '@pnpm/exe.win32-arm64': 12.0.0
-      '@pnpm/exe.win32-x64': 12.0.0
 
   pnpm@12.0.0:
     optionalDependencies:

--- a/src-tauri/src/api.rs
+++ b/src-tauri/src/api.rs
@@ -1,99 +1,17 @@
 use anyhow::anyhow;
-use keyring::Entry;
 use serde::Deserialize;
 use serde_json::json;
 use tauri::{State, async_runtime};
 use tokio::sync::Mutex;
 use tracing::Instrument;
-use twitch_api::HelixClient;
 use twitch_api::eventsub::EventType;
-use twitch_api::twitch_oauth2::{AccessToken, UserToken};
 
 use crate::error::Error;
-use crate::{AppState, HTTP};
+use crate::{AppState, auth};
 
 #[derive(Debug, Deserialize)]
 pub struct Response<T> {
     pub data: T,
-}
-
-#[derive(Debug, Deserialize)]
-struct TokenResponse {
-    access_token: String,
-    refresh_token: String,
-}
-
-pub async fn refresh_access_token(
-    helix: &HelixClient<'static, reqwest::Client>,
-) -> Result<UserToken, Error> {
-    let refresh_token = Entry::new("com.hyperion.chat", "refresh-token")?.get_password()?;
-
-    let tokens = HTTP
-        .post("https://usehyperion.app/api/auth/twitch/refresh")
-        .json(&json!({ "refresh_token": refresh_token }))
-        .send()
-        .await?
-        .error_for_status()?
-        .json::<TokenResponse>()
-        .await?;
-
-    Entry::new("com.hyperion.chat", "access-token")?.set_password(&tokens.access_token)?;
-    Entry::new("com.hyperion.chat", "refresh-token")?.set_password(&tokens.refresh_token)?;
-
-    UserToken::from_token(helix, AccessToken::new(tokens.access_token))
-        .await
-        .map_err(|err| Error::Generic(anyhow!("Failed to validate refreshed token: {err}")))
-}
-
-pub fn get_access_token(state: &AppState) -> Result<&UserToken, Error> {
-    state.token.as_ref().ok_or_else(|| {
-        tracing::error!("Attempted to retrieve access token but no token is set");
-        Error::Generic(anyhow!("Access token not set"))
-    })
-}
-
-#[tauri::command]
-pub async fn store_tokens(
-    state: State<'_, Mutex<AppState>>,
-    access_token: String,
-    refresh_token: String,
-) -> Result<(), Error> {
-    let mut state = state.lock().await;
-
-    let at_entry = Entry::new("com.hyperion.chat", "access-token")?;
-    at_entry.set_password(&access_token)?;
-
-    let rt_entry = Entry::new("com.hyperion.chat", "refresh-token")?;
-    rt_entry.set_password(&refresh_token)?;
-
-    state.token = UserToken::from_token(&state.helix, AccessToken::new(access_token))
-        .await
-        .ok();
-
-    Ok(())
-}
-
-#[tauri::command]
-pub async fn get_token(state: State<'_, Mutex<AppState>>) -> Result<Option<String>, Error> {
-    let state = state.lock().await;
-
-    Ok(state
-        .token
-        .as_ref()
-        .map(|token| token.access_token.as_str().to_string()))
-}
-
-#[tauri::command]
-pub async fn refresh_token(state: State<'_, Mutex<AppState>>) -> Result<Option<String>, Error> {
-    let mut state = state.lock().await;
-
-    let token = refresh_access_token(&state.helix).await?;
-    let access_token = token.access_token.as_str().to_string();
-    state.token = Some(token);
-
-    tracing::info!("Refreshed access token");
-
-    Ok(Some(access_token))
 }
 
 #[tracing::instrument(skip(state, is_mod))]
@@ -110,7 +28,7 @@ pub async fn join(
 
     let (token, irc, eventsub, seventv, pubsub) = {
         let state = state.lock().await;
-        let token = get_access_token(&state)?;
+        let token = auth::get_access_token(&state)?;
 
         let Some(irc) = state.irc.clone() else {
             tracing::error!("No IRC connection");

--- a/src-tauri/src/auth.rs
+++ b/src-tauri/src/auth.rs
@@ -1,0 +1,161 @@
+use anyhow::anyhow;
+use keyring::Entry;
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, State, Url, WebviewUrl, WebviewWindowBuilder};
+use tokio::sync::Mutex;
+use twitch_api::HelixClient;
+use twitch_api::twitch_oauth2::{AccessToken, UserToken};
+
+use crate::AppState;
+use crate::error::Error;
+
+const KEYRING_SERVICE: &str = "com.hyperion.chat";
+const KEYRING_USER: &str = "access-token";
+
+fn keyring_entry() -> Result<Entry, Error> {
+    Ok(Entry::new(KEYRING_SERVICE, KEYRING_USER)?)
+}
+
+/// The account a validated token belongs to, handed back to the frontend so it
+/// can build its `CurrentUser` without a second round trip.
+#[derive(Debug, Serialize)]
+pub struct AuthUser {
+    id: String,
+    login: String,
+}
+
+impl From<&UserToken> for AuthUser {
+    fn from(token: &UserToken) -> Self {
+        Self {
+            id: token.user_id.to_string(),
+            login: token.login.to_string(),
+        }
+    }
+}
+
+#[tauri::command]
+pub async fn open_twitch_login(app: AppHandle) -> Result<(), String> {
+    let auth_url =
+        WebviewUrl::External(Url::parse("https://www.twitch.tv/login").map_err(|e| e.to_string())?);
+
+    let auth_window = WebviewWindowBuilder::new(&app, "twitch-login", auth_url)
+        .title("Twitch Login")
+        .inner_size(500.0, 500.0)
+        .resizable(false)
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    let app_handle = app.clone();
+    let window_handle = auth_window.clone();
+
+    tauri::async_runtime::spawn(async move {
+        // Url without www because the auth-token cookie is set for .twitch.tv
+        let twitch_domain = Url::parse("https://twitch.tv").unwrap();
+
+        loop {
+            tokio::time::sleep(tokio::time::Duration::from_millis(800)).await;
+
+            if window_handle.is_closable().is_err() {
+                break;
+            }
+
+            if let Ok(cookies) = window_handle.cookies_for_url(twitch_domain.clone())
+                && let Some(auth_cookie) = cookies.into_iter().find(|c| c.name() == "auth-token")
+            {
+                let token_value = auth_cookie.value().to_string();
+
+                let _ = app_handle.emit_to("main", "twitch-auth-success", &token_value);
+                let _ = window_handle.close();
+
+                break;
+            }
+        }
+    });
+
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn store_token(
+    state: State<'_, Mutex<AppState>>,
+    access_token: String,
+) -> Result<AuthUser, Error> {
+    let mut state = state.lock().await;
+
+    let token = UserToken::from_token(&state.helix, AccessToken::new(access_token))
+        .await
+        .map_err(|err| {
+            tracing::error!(%err, "Rejected access token");
+            Error::Generic(anyhow!("Twitch rejected the access token: {err}"))
+        })?;
+
+    keyring_entry()?.set_password(token.access_token.as_str())?;
+
+    let user = AuthUser::from(&token);
+    tracing::info!(login = %token.login, "Stored access token");
+
+    state.token = Some(token);
+
+    Ok(user)
+}
+
+#[tauri::command]
+pub async fn clear_token(state: State<'_, Mutex<AppState>>) -> Result<(), Error> {
+    state.lock().await.token = None;
+
+    match keyring_entry()?.delete_credential() {
+        Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+        Err(err) => Err(err.into()),
+    }
+}
+
+#[tauri::command]
+pub async fn get_token(state: State<'_, Mutex<AppState>>) -> Result<Option<String>, Error> {
+    let state = state.lock().await;
+
+    Ok(state
+        .token
+        .as_ref()
+        .map(|token| token.access_token.as_str().to_string()))
+}
+
+pub fn get_access_token(state: &AppState) -> Result<&UserToken, Error> {
+    state.token.as_ref().ok_or_else(|| {
+        tracing::error!("Attempted to retrieve access token but no token is set");
+        Error::Generic(anyhow!("Access token not set"))
+    })
+}
+
+pub async fn restore_token(helix: &HelixClient<'static, reqwest::Client>) -> Option<UserToken> {
+    let entry = keyring_entry()
+        .inspect_err(|err| tracing::error!(%err, "Failed to open keyring entry"))
+        .ok()?;
+
+    let stored = match entry.get_password() {
+        Ok(stored) => stored,
+        Err(keyring::Error::NoEntry) => {
+            tracing::info!("No stored access token");
+            return None;
+        }
+        Err(err) => {
+            tracing::error!(%err, "Failed to read stored access token");
+            return None;
+        }
+    };
+
+    match UserToken::from_token(helix, AccessToken::new(stored)).await {
+        Ok(token) => {
+            tracing::info!(login = %token.login, "Restored stored access token");
+            Some(token)
+        }
+        Err(err) => {
+            tracing::warn!(%err, "Stored access token is no longer valid, clearing it");
+
+            if let Err(err) = entry.delete_credential() {
+                tracing::error!(%err, "Failed to delete invalid access token");
+            }
+
+            None
+        }
+    }
+}

--- a/src-tauri/src/auth.rs
+++ b/src-tauri/src/auth.rs
@@ -1,7 +1,7 @@
 use anyhow::anyhow;
 use keyring::Entry;
-use serde::Serialize;
-use tauri::{AppHandle, Emitter, State, Url, WebviewUrl, WebviewWindowBuilder};
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter, State, Url, WebviewUrl, WebviewWindow, WebviewWindowBuilder};
 use tokio::sync::Mutex;
 use twitch_api::HelixClient;
 use twitch_api::twitch_oauth2::{AccessToken, UserToken};
@@ -11,6 +11,9 @@ use crate::error::Error;
 
 const KEYRING_SERVICE: &str = "com.hyperion.chat";
 const KEYRING_USER: &str = "access-token";
+
+const INTEGRITY_POLL_INTERVAL: tokio::time::Duration = tokio::time::Duration::from_millis(150);
+const INTEGRITY_POLL_ATTEMPTS: u32 = 100;
 
 fn keyring_entry() -> Result<Entry, Error> {
     Ok(Entry::new(KEYRING_SERVICE, KEYRING_USER)?)
@@ -31,6 +34,106 @@ impl From<&UserToken> for AuthUser {
             login: token.login.to_string(),
         }
     }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TwitchAuth {
+    access_token: String,
+    integrity_token: Option<String>,
+    device_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct IntegrityResult {
+    #[serde(default)]
+    integrity_token: Option<String>,
+    device_id: String,
+    #[serde(default)]
+    error: Option<String>,
+}
+
+async fn eval_value(window: &WebviewWindow, js: impl Into<String>) -> Option<String> {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let tx = std::sync::Mutex::new(Some(tx));
+
+    window
+        .eval_with_callback(js, move |value| {
+            if let Ok(mut tx) = tx.lock()
+                && let Some(tx) = tx.take()
+            {
+                let _ = tx.send(value);
+            }
+        })
+        .inspect_err(|err| tracing::error!(%err, "Failed to evaluate script in login window"))
+        .ok()?;
+
+    rx.await.ok()
+}
+
+async fn fetch_integrity(window: &WebviewWindow, access_token: &str) -> Option<IntegrityResult> {
+    // The result is stashed on the window since eval can't await promises
+    let started = eval_value(
+        window,
+        format!(
+            r#"(() => {{
+                window.__hyperionAuth = null;
+
+                (async () => {{
+                    const bytes = new Uint8Array(16);
+                    crypto.getRandomValues(bytes);
+
+                    const deviceId = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+
+                    try {{
+                        const res = await fetch("https://gql.twitch.tv/integrity", {{
+                            method: "POST",
+                            headers: {{
+                                "Client-Id": "kimne78kx3ncx6brgo4mv6wki5h1ko",
+                                "X-Device-Id": deviceId,
+                                "Authorization": "OAuth {access_token}"
+                            }}
+                        }});
+
+                        if (!res.ok) {{
+                            throw new Error(`integrity request failed with status ${{res.status}}`);
+                        }}
+
+                        const data = await res.json();
+                        window.__hyperionAuth = {{ deviceId, integrityToken: data.token }};
+                    }} catch (err) {{
+                        window.__hyperionAuth = {{ deviceId, error: String(err) }};
+                    }}
+                }})();
+
+                return true;
+            }})();"#
+        ),
+    )
+    .await;
+
+    started?;
+
+    for _ in 0..INTEGRITY_POLL_ATTEMPTS {
+        tokio::time::sleep(INTEGRITY_POLL_INTERVAL).await;
+
+        let Some(value) = eval_value(window, "window.__hyperionAuth").await else {
+            continue;
+        };
+
+        if value.is_empty() || value == "null" {
+            continue;
+        }
+
+        return serde_json::from_str::<IntegrityResult>(&value)
+            .inspect_err(|err| tracing::error!(%err, "Malformed integrity result: {value}"))
+            .ok();
+    }
+
+    tracing::warn!("Timed out waiting for the integrity token");
+
+    None
 }
 
 #[tauri::command]
@@ -62,9 +165,23 @@ pub async fn open_twitch_login(app: AppHandle) -> Result<(), String> {
             if let Ok(cookies) = window_handle.cookies_for_url(twitch_domain.clone())
                 && let Some(auth_cookie) = cookies.into_iter().find(|c| c.name() == "auth-token")
             {
-                let token_value = auth_cookie.value().to_string();
+                let access_token = auth_cookie.value().to_string();
+                let integrity = fetch_integrity(&window_handle, &access_token).await;
 
-                let _ = app_handle.emit_to("main", "twitch-auth-success", &token_value);
+                if let Some(error) = integrity.as_ref().and_then(|result| result.error.as_ref()) {
+                    tracing::warn!(%error, "Failed to fetch an integrity token");
+                }
+
+                let auth = TwitchAuth {
+                    access_token,
+                    device_id: integrity
+                        .as_ref()
+                        .map(|result| result.device_id.clone())
+                        .unwrap_or_default(),
+                    integrity_token: integrity.and_then(|result| result.integrity_token),
+                };
+
+                let _ = app_handle.emit_to("main", "twitch-auth-success", &auth);
                 let _ = window_handle.close();
 
                 break;

--- a/src-tauri/src/auth.rs
+++ b/src-tauri/src/auth.rs
@@ -75,13 +75,21 @@ pub struct TwitchAuth {
     integrity: Option<Integrity>,
 }
 
+// WebView2 serializes JS numbers as doubles :/
+fn deserialize_epoch_ms<'de, D>(deserializer: D) -> Result<Option<i64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(Option::<f64>::deserialize(deserializer)?.map(|millis| millis as i64))
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct IntegrityResult {
     device_id: String,
     #[serde(default)]
     token: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_epoch_ms")]
     expiration: Option<i64>,
     #[serde(default)]
     error: Option<String>,

--- a/src-tauri/src/auth.rs
+++ b/src-tauri/src/auth.rs
@@ -1,7 +1,12 @@
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
 use anyhow::anyhow;
 use keyring::Entry;
 use serde::{Deserialize, Serialize};
-use tauri::{AppHandle, Emitter, State, Url, WebviewUrl, WebviewWindow, WebviewWindowBuilder};
+use tauri::{
+    AppHandle, Emitter, Manager, State, Url, WebviewUrl, WebviewWindow, WebviewWindowBuilder,
+};
 use tokio::sync::Mutex;
 use twitch_api::HelixClient;
 use twitch_api::twitch_oauth2::{AccessToken, UserToken};
@@ -12,15 +17,27 @@ use crate::error::Error;
 const KEYRING_SERVICE: &str = "com.hyperion.chat";
 const KEYRING_USER: &str = "access-token";
 
+const LOGIN_WINDOW_LABEL: &str = "twitch-login";
+const INTEGRITY_WINDOW_LABEL: &str = "twitch-integrity";
+
+/// How long to wait for the in-page integrity request before giving up.
 const INTEGRITY_POLL_INTERVAL: tokio::time::Duration = tokio::time::Duration::from_millis(150);
 const INTEGRITY_POLL_ATTEMPTS: u32 = 100;
+
+/// Treat a token as spent slightly before it actually lapses.
+const INTEGRITY_EXPIRY_SKEW_MS: i64 = 5 * 60 * 1000;
 
 fn keyring_entry() -> Result<Entry, Error> {
     Ok(Entry::new(KEYRING_SERVICE, KEYRING_USER)?)
 }
 
-/// The account a validated token belongs to, handed back to the frontend so it
-/// can build its `CurrentUser` without a second round trip.
+fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_millis() as i64)
+        .unwrap_or_default()
+}
+
 #[derive(Debug, Serialize)]
 pub struct AuthUser {
     id: String,
@@ -36,22 +53,79 @@ impl From<&UserToken> for AuthUser {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Integrity {
+    token: String,
+    device_id: String,
+    expiration: i64,
+}
+
+impl Integrity {
+    fn is_stale(&self) -> bool {
+        self.expiration.saturating_sub(INTEGRITY_EXPIRY_SKEW_MS) <= now_ms()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TwitchAuth {
     access_token: String,
-    integrity_token: Option<String>,
-    device_id: String,
+    #[serde(default)]
+    integrity: Option<Integrity>,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct IntegrityResult {
-    #[serde(default)]
-    integrity_token: Option<String>,
     device_id: String,
     #[serde(default)]
+    token: Option<String>,
+    #[serde(default)]
+    expiration: Option<i64>,
+    #[serde(default)]
     error: Option<String>,
+}
+
+impl IntegrityResult {
+    fn into_integrity(self) -> Option<Integrity> {
+        Some(Integrity {
+            token: self.token?,
+            device_id: self.device_id,
+            expiration: self.expiration?,
+        })
+    }
+}
+
+fn read_credentials() -> Option<TwitchAuth> {
+    let entry = keyring_entry()
+        .inspect_err(|err| tracing::error!(%err, "Failed to open keyring entry"))
+        .ok()?;
+
+    let stored = match entry.get_password() {
+        Ok(stored) => stored,
+        Err(keyring::Error::NoEntry) => {
+            tracing::info!("No stored credentials");
+            return None;
+        }
+        Err(err) => {
+            tracing::error!(%err, "Failed to read stored credentials");
+            return None;
+        }
+    };
+
+    match serde_json::from_str(&stored) {
+        Ok(auth) => Some(auth),
+        Err(_) => Some(TwitchAuth {
+            access_token: stored,
+            integrity: None,
+        }),
+    }
+}
+
+fn write_credentials(auth: &TwitchAuth) -> Result<(), Error> {
+    keyring_entry()?.set_password(&serde_json::to_string(auth)?)?;
+    Ok(())
 }
 
 async fn eval_value(window: &WebviewWindow, js: impl Into<String>) -> Option<String> {
@@ -66,19 +140,40 @@ async fn eval_value(window: &WebviewWindow, js: impl Into<String>) -> Option<Str
                 let _ = tx.send(value);
             }
         })
-        .inspect_err(|err| tracing::error!(%err, "Failed to evaluate script in login window"))
+        .inspect_err(|err| tracing::error!(%err, "Failed to evaluate script in webview"))
         .ok()?;
 
     rx.await.ok()
 }
 
+async fn wait_for_document(window: &WebviewWindow) -> bool {
+    for _ in 0..INTEGRITY_POLL_ATTEMPTS {
+        let ready = eval_value(window, "document.readyState")
+            .await
+            .and_then(|value| serde_json::from_str::<String>(&value).ok());
+
+        if ready.as_deref() == Some("complete") {
+            return true;
+        }
+
+        tokio::time::sleep(INTEGRITY_POLL_INTERVAL).await;
+    }
+
+    tracing::warn!("Timed out waiting for a webview to finish loading");
+
+    false
+}
+
 async fn fetch_integrity(window: &WebviewWindow, access_token: &str) -> Option<IntegrityResult> {
-    // The result is stashed on the window since eval can't await promises
-    let started = eval_value(
+    if !wait_for_document(window).await {
+        return None;
+    }
+
+    eval_value(
         window,
         format!(
             r#"(() => {{
-                window.__hyperionAuth = null;
+                window.__hyperionIntegrity = null;
 
                 (async () => {{
                     const bytes = new Uint8Array(16);
@@ -101,24 +196,25 @@ async fn fetch_integrity(window: &WebviewWindow, access_token: &str) -> Option<I
                         }}
 
                         const data = await res.json();
-                        window.__hyperionAuth = {{ deviceId, integrityToken: data.token }};
+
+                        window.__hyperionIntegrity = {{
+                            deviceId,
+                            token: data.token,
+                            expiration: data.expiration
+                        }};
                     }} catch (err) {{
-                        window.__hyperionAuth = {{ deviceId, error: String(err) }};
+                        window.__hyperionIntegrity = {{ deviceId, error: String(err) }};
                     }}
                 }})();
-
-                return true;
             }})();"#
         ),
     )
-    .await;
-
-    started?;
+    .await?;
 
     for _ in 0..INTEGRITY_POLL_ATTEMPTS {
         tokio::time::sleep(INTEGRITY_POLL_INTERVAL).await;
 
-        let Some(value) = eval_value(window, "window.__hyperionAuth").await else {
+        let Some(value) = eval_value(window, "window.__hyperionIntegrity").await else {
             continue;
         };
 
@@ -136,12 +232,85 @@ async fn fetch_integrity(window: &WebviewWindow, access_token: &str) -> Option<I
     None
 }
 
+async fn refresh_integrity(app: &AppHandle, access_token: &str) -> Option<Integrity> {
+    if let Some(stale) = app.get_webview_window(INTEGRITY_WINDOW_LABEL) {
+        let _ = stale.close();
+    }
+
+    let url = Url::parse("https://www.twitch.tv/")
+        .inspect_err(|err| tracing::error!(%err, "Invalid integrity url"))
+        .ok()?;
+
+    let window = WebviewWindowBuilder::new(app, INTEGRITY_WINDOW_LABEL, WebviewUrl::External(url))
+        .title("Twitch")
+        .visible(false)
+        .build()
+        .inspect_err(|err| tracing::error!(%err, "Failed to open the integrity webview"))
+        .ok()?;
+
+    let result = fetch_integrity(&window, access_token).await;
+    let _ = window.close();
+
+    if let Some(error) = result.as_ref().and_then(|result| result.error.as_ref()) {
+        tracing::warn!(%error, "Failed to refresh the integrity token");
+    }
+
+    result?.into_integrity()
+}
+
+pub async fn ensure_integrity(app: &AppHandle) -> Option<Integrity> {
+    let state = app.state::<Mutex<AppState>>();
+
+    let (access_token, integrity, refresh_lock) = {
+        let state = state.lock().await;
+
+        (
+            state
+                .token
+                .as_ref()
+                .map(|token| token.access_token.as_str().to_string()),
+            state.integrity.clone(),
+            Arc::clone(&state.integrity_refresh),
+        )
+    };
+
+    let access_token = access_token?;
+
+    if let Some(integrity) = integrity.filter(|integrity| !integrity.is_stale()) {
+        return Some(integrity);
+    }
+
+    let _guard = refresh_lock.lock().await;
+
+    // Whoever held the lock may have refreshed it while we waited.
+    let current = state.lock().await.integrity.clone();
+
+    if let Some(integrity) = current.filter(|integrity| !integrity.is_stale()) {
+        return Some(integrity);
+    }
+
+    let integrity = refresh_integrity(app, &access_token).await?;
+
+    state.lock().await.integrity = Some(integrity.clone());
+
+    if let Err(err) = write_credentials(&TwitchAuth {
+        access_token: access_token.clone(),
+        integrity: Some(integrity.clone()),
+    }) {
+        tracing::error!(%err, "Failed to persist the refreshed integrity token");
+    }
+
+    tracing::info!("Refreshed integrity token");
+
+    Some(integrity)
+}
+
 #[tauri::command]
 pub async fn open_twitch_login(app: AppHandle) -> Result<(), String> {
     let auth_url =
         WebviewUrl::External(Url::parse("https://www.twitch.tv/login").map_err(|e| e.to_string())?);
 
-    let auth_window = WebviewWindowBuilder::new(&app, "twitch-login", auth_url)
+    let auth_window = WebviewWindowBuilder::new(&app, LOGIN_WINDOW_LABEL, auth_url)
         .title("Twitch Login")
         .inner_size(500.0, 500.0)
         .resizable(false)
@@ -166,19 +335,15 @@ pub async fn open_twitch_login(app: AppHandle) -> Result<(), String> {
                 && let Some(auth_cookie) = cookies.into_iter().find(|c| c.name() == "auth-token")
             {
                 let access_token = auth_cookie.value().to_string();
-                let integrity = fetch_integrity(&window_handle, &access_token).await;
+                let result = fetch_integrity(&window_handle, &access_token).await;
 
-                if let Some(error) = integrity.as_ref().and_then(|result| result.error.as_ref()) {
+                if let Some(error) = result.as_ref().and_then(|result| result.error.as_ref()) {
                     tracing::warn!(%error, "Failed to fetch an integrity token");
                 }
 
                 let auth = TwitchAuth {
                     access_token,
-                    device_id: integrity
-                        .as_ref()
-                        .map(|result| result.device_id.clone())
-                        .unwrap_or_default(),
-                    integrity_token: integrity.and_then(|result| result.integrity_token),
+                    integrity: result.and_then(|result| result.into_integrity()),
                 };
 
                 let _ = app_handle.emit_to("main", "twitch-auth-success", &auth);
@@ -195,22 +360,26 @@ pub async fn open_twitch_login(app: AppHandle) -> Result<(), String> {
 #[tauri::command]
 pub async fn store_token(
     state: State<'_, Mutex<AppState>>,
-    access_token: String,
+    auth: TwitchAuth,
 ) -> Result<AuthUser, Error> {
     let mut state = state.lock().await;
 
-    let token = UserToken::from_token(&state.helix, AccessToken::new(access_token))
+    let token = UserToken::from_token(&state.helix, AccessToken::new(auth.access_token))
         .await
         .map_err(|err| {
             tracing::error!(%err, "Rejected access token");
             Error::Generic(anyhow!("Twitch rejected the access token: {err}"))
         })?;
 
-    keyring_entry()?.set_password(token.access_token.as_str())?;
+    write_credentials(&TwitchAuth {
+        access_token: token.access_token.as_str().to_string(),
+        integrity: auth.integrity.clone(),
+    })?;
 
     let user = AuthUser::from(&token);
-    tracing::info!(login = %token.login, "Stored access token");
+    tracing::info!(login = %token.login, "Stored credentials");
 
+    state.integrity = auth.integrity;
     state.token = Some(token);
 
     Ok(user)
@@ -218,7 +387,10 @@ pub async fn store_token(
 
 #[tauri::command]
 pub async fn clear_token(state: State<'_, Mutex<AppState>>) -> Result<(), Error> {
-    state.lock().await.token = None;
+    let mut state = state.lock().await;
+
+    state.token = None;
+    state.integrity = None;
 
     match keyring_entry()?.delete_credential() {
         Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
@@ -236,6 +408,11 @@ pub async fn get_token(state: State<'_, Mutex<AppState>>) -> Result<Option<Strin
         .map(|token| token.access_token.as_str().to_string()))
 }
 
+#[tauri::command]
+pub async fn get_integrity(app: AppHandle) -> Result<Option<Integrity>, Error> {
+    Ok(ensure_integrity(&app).await)
+}
+
 pub fn get_access_token(state: &AppState) -> Result<&UserToken, Error> {
     state.token.as_ref().ok_or_else(|| {
         tracing::error!("Attempted to retrieve access token but no token is set");
@@ -243,36 +420,42 @@ pub fn get_access_token(state: &AppState) -> Result<&UserToken, Error> {
     })
 }
 
-pub async fn restore_token(helix: &HelixClient<'static, reqwest::Client>) -> Option<UserToken> {
-    let entry = keyring_entry()
-        .inspect_err(|err| tracing::error!(%err, "Failed to open keyring entry"))
-        .ok()?;
+pub struct Restored {
+    pub token: Option<UserToken>,
+    pub integrity: Option<Integrity>,
+}
 
-    let stored = match entry.get_password() {
-        Ok(stored) => stored,
-        Err(keyring::Error::NoEntry) => {
-            tracing::info!("No stored access token");
-            return None;
-        }
-        Err(err) => {
-            tracing::error!(%err, "Failed to read stored access token");
-            return None;
-        }
+pub async fn restore_credentials(helix: &HelixClient<'static, reqwest::Client>) -> Restored {
+    let Some(stored) = read_credentials() else {
+        return Restored {
+            token: None,
+            integrity: None,
+        };
     };
 
-    match UserToken::from_token(helix, AccessToken::new(stored)).await {
+    match UserToken::from_token(helix, AccessToken::new(stored.access_token)).await {
         Ok(token) => {
-            tracing::info!(login = %token.login, "Restored stored access token");
-            Some(token)
+            tracing::info!(login = %token.login, "Restored stored credentials");
+
+            Restored {
+                token: Some(token),
+                integrity: stored.integrity,
+            }
         }
         Err(err) => {
             tracing::warn!(%err, "Stored access token is no longer valid, clearing it");
 
-            if let Err(err) = entry.delete_credential() {
-                tracing::error!(%err, "Failed to delete invalid access token");
+            // The integrity token is bound to this session, so it goes with it.
+            if let Ok(entry) = keyring_entry()
+                && let Err(err) = entry.delete_credential()
+            {
+                tracing::error!(%err, "Failed to delete invalid credentials");
             }
 
-            None
+            Restored {
+                token: None,
+                integrity: None,
+            }
         }
     }
 }

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -17,6 +17,9 @@ pub enum Error {
     Io(#[from] std::io::Error),
 
     #[error(transparent)]
+    Json(#[from] serde_json::Error),
+
+    #[error(transparent)]
     Keyring(#[from] keyring::Error),
 
     #[error(transparent)]

--- a/src-tauri/src/eventsub/mod.rs
+++ b/src-tauri/src/eventsub/mod.rs
@@ -9,7 +9,7 @@ use tauri::ipc::Channel;
 use tauri::{AppHandle, Manager, State};
 
 use crate::AppState;
-use crate::api::get_access_token;
+use crate::auth::get_access_token;
 use crate::error::Error;
 use crate::ws::{channel_sink, forward_to_channel};
 

--- a/src-tauri/src/irc/mod.rs
+++ b/src-tauri/src/irc/mod.rs
@@ -16,7 +16,7 @@ use tauri::{State, async_runtime};
 use tokio::sync::Mutex;
 
 use crate::AppState;
-use crate::api::get_access_token;
+use crate::auth::get_access_token;
 use crate::error::Error as AppError;
 use crate::irc::message::IrcMessage;
 use crate::ws::channel_sink;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -19,9 +19,8 @@ use twitch_api::HelixClient;
 use twitch_api::twitch_oauth2::UserToken;
 use ws::ChannelSink;
 
-use crate::api::refresh_access_token;
-
 mod api;
+mod auth;
 mod commands;
 mod error;
 mod eventsub;
@@ -118,8 +117,11 @@ pub fn run() {
 
             app_handle.plugin(svelte)?;
 
+            // Validate any stored token before the frontend's first layout load
+            // asks for it; an invalid one resolves to `None` and the frontend
+            // redirects to the login screen.
             async_runtime::block_on(async {
-                state.token = refresh_access_token(&state.helix).await.ok();
+                state.token = auth::restore_token(&state.helix).await;
             });
 
             app.manage(Mutex::new(state));
@@ -136,9 +138,10 @@ fn get_handler() -> impl Fn(Invoke) -> bool {
         api::join,
         api::leave,
         api::rejoin,
-        api::store_tokens,
-        api::get_token,
-        api::refresh_token,
+        auth::clear_token,
+        auth::get_token,
+        auth::open_twitch_login,
+        auth::store_token,
         commands::fetch_recent_messages,
         commands::get_cache_size,
         commands::get_about_info,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@
 
 use std::sync::{Arc, LazyLock};
 
+use auth::Integrity;
 use eventsub::EventSubClient;
 use eventsub::client::NotificationPayload;
 use irc::IrcClient;
@@ -46,6 +47,10 @@ pub static HTTP: LazyLock<reqwest::Client> = LazyLock::new(|| {
 pub struct AppState {
     helix: HelixClient<'static, reqwest::Client>,
     token: Option<UserToken>,
+    integrity: Option<Integrity>,
+    // Held across an integrity refresh so concurrent callers queue behind the
+    // one webview instead of each opening their own.
+    integrity_refresh: Arc<Mutex<()>>,
     irc: Option<IrcClient>,
     eventsub: Option<Arc<EventSubClient>>,
     seventv: Option<Arc<SeventTvClient>>,
@@ -63,6 +68,8 @@ impl Default for AppState {
         Self {
             helix: HelixClient::new(),
             token: None,
+            integrity: None,
+            integrity_refresh: Arc::new(Mutex::new(())),
             irc: None,
             eventsub: None,
             seventv: None,
@@ -117,14 +124,20 @@ pub fn run() {
 
             app_handle.plugin(svelte)?;
 
-            // Validate any stored token before the frontend's first layout load
-            // asks for it; an invalid one resolves to `None` and the frontend
-            // redirects to the login screen.
             async_runtime::block_on(async {
-                state.token = auth::restore_token(&state.helix).await;
+                let restored = auth::restore_credentials(&state.helix).await;
+
+                state.token = restored.token;
+                state.integrity = restored.integrity;
             });
 
             app.manage(Mutex::new(state));
+
+            let handle = app_handle.clone();
+
+            async_runtime::spawn(async move {
+                auth::ensure_integrity(&handle).await;
+            });
 
             Ok(())
         })
@@ -139,6 +152,7 @@ fn get_handler() -> impl Fn(Invoke) -> bool {
         api::leave,
         api::rejoin,
         auth::clear_token,
+        auth::get_integrity,
         auth::get_token,
         auth::open_twitch_login,
         auth::store_token,

--- a/src-tauri/src/pubsub/mod.rs
+++ b/src-tauri/src/pubsub/mod.rs
@@ -9,7 +9,7 @@ use tauri::{AppHandle, Manager, State, async_runtime};
 use tokio::sync::Mutex;
 
 use crate::AppState;
-use crate::api::get_access_token;
+use crate::auth::get_access_token;
 use crate::error::Error;
 use crate::ws::{channel_sink, forward_to_channel};
 

--- a/src/lib/twitch/auth.ts
+++ b/src/lib/twitch/auth.ts
@@ -8,115 +8,51 @@ import { log } from "$lib/log";
 import { CurrentUser } from "$lib/models/current-user.svelte";
 import { storage } from "$lib/stores";
 
-export const SCOPES = [
-	// Channel
-	"channel:edit:commercial",
-	"channel:manage:broadcast",
-	"channel:manage:moderators",
-	"channel:manage:polls",
-	"channel:manage:predictions",
-	"channel:manage:raids",
-	"channel:manage:redemptions",
-	"channel:manage:vips",
-	"channel:moderate",
-	"channel:read:editors",
-	"channel:read:hype_train",
-	"channel:read:polls",
-	"channel:read:predictions",
-	"channel:read:redemptions",
-
-	// Chat
-	"chat:edit",
-	"chat:read",
-
-	// Moderation
-	"moderator:manage:announcements",
-	"moderator:manage:automod",
-	"moderator:manage:banned_users",
-	"moderator:manage:blocked_terms",
-	"moderator:manage:chat_messages",
-	"moderator:manage:chat_settings",
-	"moderator:manage:shield_mode",
-	"moderator:manage:shoutouts",
-	"moderator:manage:unban_requests",
-	"moderator:manage:warnings",
-	"moderator:read:chatters",
-	"moderator:read:moderators",
-	"moderator:read:suspicious_users",
-	"moderator:read:vips",
-
-	// User
-	"user:manage:blocked_users",
-	"user:manage:chat_color",
-	"user:manage:whispers",
-	"user:read:blocked_users",
-	"user:read:chat",
-	"user:read:emotes",
-	"user:read:follows",
-	"user:read:moderated_channels",
-	"user:write:chat",
-
-	// Other
-	"clips:edit",
-	"whispers:read",
-];
-
-async function getTokens(id: string) {
-	const response = await fetch(`https://usehyperion.app/api/auth/twitch/tokens?user_id=${id}`);
-	if (!response.ok) return null;
-
-	return response.json();
+interface AuthUser {
+	id: string;
+	login: string;
 }
 
-export async function handleDeepLink(url: URL) {
-	if (url.host !== "auth") return;
+export async function completeLogin(accessToken: string) {
+	const account = await invoke<AuthUser>("store_token", { accessToken });
 
-	const userId = url.searchParams.get("user_id");
+	app.twitch.token = accessToken;
 
-	if (!userId) {
-		throw new Error("Missing user id");
-	}
-
-	const tokens = await getTokens(userId);
-	if (!tokens) {
-		log.warn(`No tokens found for ${userId}`);
-		return;
-	}
-
-	await invoke("store_tokens", {
-		accessToken: tokens.access_token,
-		refreshToken: tokens.refresh_token,
-	});
-
-	const user = await app.twitch.users.fetch(userId);
+	const user = await app.twitch.users.fetch(account.id);
 	storage.state.user = user.data;
 
 	app.user = new CurrentUser(user);
+
+	log.info(`Logged in as ${account.login}`);
 
 	await storage.saveNow();
 	await goto("/");
 }
 
 export async function logOut() {
-	if (!app.twitch.token) {
-		await goto("/auth/login");
-		return;
-	}
+	const token = app.twitch.token;
 
 	storage.state.user = null;
 
 	app.user = null;
 	app.focused = null;
+	app.twitch.token = null;
 
 	await tick();
 	await storage.saveNow();
 
-	await fetch("https://usehyperion.app/api/auth/twitch/revoke", {
-		method: "POST",
-		headers: {
-			Authorization: app.twitch.token,
-		},
-	});
+	// Drop the keyring entry too, otherwise the next start up restores the token
+	// and logs straight back in.
+	await invoke("clear_token");
+
+	if (token) {
+		await fetch("https://usehyperion.app/api/auth/twitch/revoke", {
+			method: "POST",
+			headers: {
+				Authorization: token,
+			},
+		});
+	}
 
 	log.info("User logged out");
 	await goto("/auth/login");

--- a/src/lib/twitch/auth.ts
+++ b/src/lib/twitch/auth.ts
@@ -13,16 +13,23 @@ interface AuthUser {
 	login: string;
 }
 
+export interface Integrity {
+	token: string;
+	deviceId: string;
+	expiration: number;
+}
+
 export interface TwitchAuth {
 	accessToken: string;
-	integrityToken: string | null;
-	deviceId: string;
+	integrity: Integrity | null;
+}
+
+export function getIntegrity() {
+	return invoke<Integrity | null>("get_integrity");
 }
 
 export async function completeLogin(auth: TwitchAuth) {
-	const account = await invoke<AuthUser>("store_token", {
-		accessToken: auth.accessToken,
-	});
+	const account = await invoke<AuthUser>("store_token", { auth });
 
 	app.twitch.token = auth.accessToken;
 

--- a/src/lib/twitch/auth.ts
+++ b/src/lib/twitch/auth.ts
@@ -40,6 +40,7 @@ export async function completeLogin(auth: TwitchAuth) {
 
 	log.info(`Logged in as ${account.login}`);
 
+	await tick();
 	await storage.saveNow();
 	await goto("/");
 }

--- a/src/lib/twitch/auth.ts
+++ b/src/lib/twitch/auth.ts
@@ -13,10 +13,18 @@ interface AuthUser {
 	login: string;
 }
 
-export async function completeLogin(accessToken: string) {
-	const account = await invoke<AuthUser>("store_token", { accessToken });
+export interface TwitchAuth {
+	accessToken: string;
+	integrityToken: string | null;
+	deviceId: string;
+}
 
-	app.twitch.token = accessToken;
+export async function completeLogin(auth: TwitchAuth) {
+	const account = await invoke<AuthUser>("store_token", {
+		accessToken: auth.accessToken,
+	});
+
+	app.twitch.token = auth.accessToken;
 
 	const user = await app.twitch.users.fetch(account.id);
 	storage.state.user = user.data;

--- a/src/lib/twitch/client.ts
+++ b/src/lib/twitch/client.ts
@@ -59,8 +59,6 @@ function cleanQuery(params: QueryParams): QueryParams {
 }
 
 export class TwitchClient {
-	public static readonly CLIENT_ID = "2z7vk7rabefjdhey6m5cxfxsbspw7c";
-	public static readonly REDIRECT_URL = "https://usehyperion.app/api/auth/twitch/callback";
 	public static readonly DEFAULT_TIMEOUT = 15_000;
 
 	#refreshing: Promise<string | null> | null = null;
@@ -143,6 +141,7 @@ export class TwitchClient {
 
 		const query = options.params ? cleanQuery(options.params) : undefined;
 		const timeout = options.timeout ?? TwitchClient.DEFAULT_TIMEOUT;
+
 		const send = () => this.#send<T>(method, path, query, options.body, timeout);
 
 		if (method === "GET") {
@@ -169,7 +168,7 @@ export class TwitchClient {
 					query,
 					headers: {
 						Authorization: `Bearer ${this.token}`,
-						"Client-Id": TwitchClient.CLIENT_ID,
+						"Client-Id": "kimne78kx3ncx6brgo4mv6wki5h1ko",
 					},
 					body,
 					signal: AbortSignal.timeout(timeout),

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,30 +2,20 @@
 	import "../styles/app.css";
 	import { setHotkeysContext } from "@tanstack/svelte-hotkeys";
 	import { invoke } from "@tauri-apps/api/core";
-	import { onOpenUrl } from "@tauri-apps/plugin-deep-link";
 	import { ModeWatcher } from "mode-watcher";
-	import { onDestroy, onMount } from "svelte";
+	import { onMount } from "svelte";
 
 	import { app } from "$lib/app.svelte";
 	import TitleBar from "$lib/components/TitleBar.svelte";
 	import { log } from "$lib/log";
 	import { settings } from "$lib/settings";
 	import { injectTheme } from "$lib/themes";
-	import { handleDeepLink } from "$lib/twitch/auth";
 
 	const { children } = $props();
 
-	let unlisten: () => void;
-
-	onMount(async () => {
+	onMount(() => {
 		app.splits.cleanup();
-
-		unlisten = await onOpenUrl(async (urls) => {
-			await handleDeepLink(new URL(urls[0]));
-		});
 	});
-
-	onDestroy(() => unlisten?.());
 
 	setHotkeysContext({
 		hotkey: {

--- a/src/routes/auth/login/+page.svelte
+++ b/src/routes/auth/login/+page.svelte
@@ -1,20 +1,33 @@
 <script lang="ts">
-	import { openUrl } from "@tauri-apps/plugin-opener";
+	import { invoke } from "@tauri-apps/api/core";
+	import { listen } from "@tauri-apps/api/event";
+	import { onMount } from "svelte";
 
 	import Button from "$lib/components/ui/Button.svelte";
-	import { SCOPES } from "$lib/twitch/auth";
-	import { TwitchClient } from "$lib/twitch/client";
+	import { log } from "$lib/log";
+	import { completeLogin } from "$lib/twitch/auth";
 
 	import Twitch from "~icons/local/twitch";
 
-	const params = new URLSearchParams({
-		client_id: TwitchClient.CLIENT_ID,
-		redirect_uri: TwitchClient.REDIRECT_URL,
-		response_type: "code",
-		scope: SCOPES.join(" "),
+	let error = $state<string | null>(null);
+
+	onMount(() => {
+		const unlisten = listen<string>("twitch-auth-success", async ({ payload }) => {
+			try {
+				await completeLogin(payload);
+			} catch (err) {
+				error = "Could not complete sign in. Please try again.";
+				log.error(`Failed to complete login: ${err}`);
+			}
+		});
+
+		return () => void unlisten.then((fn) => fn());
 	});
 
-	const authUrl = `https://id.twitch.tv/oauth2/authorize?${params.toString()}`;
+	async function handleLogIn() {
+		error = null;
+		await invoke("open_twitch_login");
+	}
 </script>
 
 <img class="size-16" src="/logo.svg" alt="Hyperion logo" />
@@ -25,7 +38,11 @@
 	<p class="max-w-sm text-muted-foreground">Connect your Twitch account to start chatting.</p>
 </div>
 
-<Button class="h-12" size="lg" onclickwait={() => openUrl(authUrl.toString())}>
+<Button class="h-12" size="lg" onclickwait={() => handleLogIn()}>
 	<Twitch class="size-5 fill-white" />
 	Log in with Twitch
 </Button>
+
+{#if error}
+	<p class="text-sm text-destructive">{error}</p>
+{/if}

--- a/src/routes/auth/login/+page.svelte
+++ b/src/routes/auth/login/+page.svelte
@@ -5,14 +5,14 @@
 
 	import Button from "$lib/components/ui/Button.svelte";
 	import { log } from "$lib/log";
-	import { completeLogin } from "$lib/twitch/auth";
+	import { completeLogin, type TwitchAuth } from "$lib/twitch/auth";
 
 	import Twitch from "~icons/local/twitch";
 
 	let error = $state<string | null>(null);
 
 	onMount(() => {
-		const unlisten = listen<string>("twitch-auth-success", async ({ payload }) => {
+		const unlisten = listen<TwitchAuth>("twitch-auth-success", async ({ payload }) => {
 			try {
 				await completeLogin(payload);
 			} catch (err) {


### PR DESCRIPTION
Major breakthrough here. After being frustrated with the limitations around Helix, I decided to dig more into how their protected GQL endpoints work, and discovered that the auth token stored in cookies is the token used for the authorization header.

Tauri conveniently provides a function to extract the cookies from a url, so the entire auth process can be embedded instead of having to bridge through the marketing site.

**However**, there are two big major consequences by switching to a god token (that's the term I'm coining):

1. EventSub can no longer be used, PubSub needs to be implemented
2. All Helix calls needs to be migrated to GraphQL

Both points will be addressed in following PRs and stacked.